### PR TITLE
GH-82: Priority UI channel

### DIFF
--- a/MiscCommon/DDSHelper.h
+++ b/MiscCommon/DDSHelper.h
@@ -15,7 +15,7 @@
 
 namespace MiscCommon
 {
-    inline void findCommanderServer(std::string* _host, std::string* _port)
+    inline void findCommanderServerImpl(std::string* _host, std::string* _port, const std::string& _name)
     {
         if (nullptr == _host || nullptr == _port)
             throw std::invalid_argument("findCommanderServer: Arguments must not be null");
@@ -28,8 +28,18 @@ namespace MiscCommon
 
         boost::property_tree::ptree pt;
         boost::property_tree::ini_parser::read_ini(sSrvCfg, pt);
-        *_host = pt.get<std::string>("server.host");
-        *_port = pt.get<std::string>("server.port");
+        *_host = pt.get<std::string>(_name + ".host");
+        *_port = pt.get<std::string>(_name + ".port");
+    }
+
+    inline void findCommanderServer(std::string* _host, std::string* _port)
+    {
+        findCommanderServerImpl(_host, _port, "server");
+    }
+
+    inline void findCommanderUI(std::string* _host, std::string* _port)
+    {
+        findCommanderServerImpl(_host, _port, "ui");
     }
 };
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -39,6 +39,8 @@ Modified: Optimized key-value persistence to shared memory.
 ### dds-key-value
 Fixed: stability improvements.    
 Added: Multiple subscribers for key-value notifications. (GH-70)   
+Added: If task can only read property then property will not be propagated. (GH-55)   
+Added: User task can subscribe to error events, for example, error will be send if property can not be propagated. (GH-55)   
 
 ### dds-user-defaults
 Modified: use string log severity values instead of numbers. (GH-49)    

--- a/dds-agent-cmd/src/main.cpp
+++ b/dds-agent-cmd/src/main.cpp
@@ -41,8 +41,8 @@ int main(int argc, char* argv[])
     string sPort;
     try
     {
-        // Process server info file.
-        findCommanderServer(&sHost, &sPort);
+        // We want to connect to commnader's UI channel
+        findCommanderUI(&sHost, &sPort);
     }
     catch (exception& e)
     {

--- a/dds-agent/src/AgentConnectionManager.cpp
+++ b/dds-agent/src/AgentConnectionManager.cpp
@@ -25,7 +25,6 @@ CAgentConnectionManager::CAgentConnectionManager(const SOptions_t& _options, boo
     , m_signals(_io_service)
     , m_options(_options)
     , m_bStarted(false)
-    , m_UI_end_point(tcp::v4(), 0) // Let the OS pick a random available port
     , m_deadlineTimer(std::make_shared<boost::asio::deadline_timer>(m_service, boost::posix_time::milliseconds(1000)))
 {
     // Register to handle the signals that indicate when the server should exit.
@@ -126,8 +125,9 @@ void CAgentConnectionManager::start()
 
         // Subscribe for cmdSTOP_USER_TASK
         std::function<bool(SCommandAttachmentImpl<cmdSTOP_USER_TASK>::ptr_t _attachment, CCommanderChannel * _channel)>
-            fSTOP_USER_TASK = [this](SCommandAttachmentImpl<cmdSTOP_USER_TASK>::ptr_t _attachment,
-                                     CCommanderChannel* _channel) -> bool
+            fSTOP_USER_TASK =
+                [this](SCommandAttachmentImpl<cmdSTOP_USER_TASK>::ptr_t _attachment, CCommanderChannel* _channel)
+                    -> bool
         {
             // TODO: adjust the algorithm if we would need to support several agents
             // we have only one agent (newAgent) at the moment
@@ -149,8 +149,7 @@ void CAgentConnectionManager::start()
                                           return;
 
                                       // Start the UI agent server
-                                      m_UIConnectionMng =
-                                          make_shared<CUIConnectionManager>(m_UI_io_service, m_UI_end_point);
+                                      m_UIConnectionMng = make_shared<CUIConnectionManager>();
                                       m_UIConnectionMng->setCommanderChannel(m_agent);
                                       m_UIConnectionMng->start(false, 2);
 

--- a/dds-agent/src/AgentConnectionManager.cpp
+++ b/dds-agent/src/AgentConnectionManager.cpp
@@ -323,11 +323,26 @@ bool CAgentConnectionManager::on_cmdSIMPLE_MSG(SCommandAttachmentImpl<cmdSIMPLE_
     switch (_attachment->m_srcCommand)
     {
         case cmdUPDATE_KEY:
-            if (m_UIConnectionMng)
-                m_UIConnectionMng->notifyAboutSimpleMsg(_attachment);
+        {
+            if (_attachment->m_msgSeverity != MiscCommon::error)
+            {
+                if (m_UIConnectionMng)
+                    m_UIConnectionMng->notifyAboutSimpleMsg(_attachment);
+                else
+                    LOG(warning) << "UI connection manager doesn't run. Skipping simple message broadcasting.";
+            }
             else
-                LOG(warning) << "UI connection manager doesn't run. Skipping simple message broadcasting.";
+            {
+                // We got an error message about property propagation
+                LOG(MiscCommon::error) << _attachment->m_sMsg;
+                // Forward error message to UI channel
+                if (m_UIConnectionMng)
+                    m_UIConnectionMng->notifyAboutSimpleMsg(_attachment);
+                else
+                    LOG(warning) << "UI connection manager doesn't run. Skipping forwarding of the error message.";
+            }
             return true;
+        }
 
         default:
             LOG(debug) << "Received command cmdSIMPLE_MSG does not have a listener";

--- a/dds-agent/src/AgentConnectionManager.h
+++ b/dds-agent/src/AgentConnectionManager.h
@@ -55,8 +55,6 @@ namespace dds
         childrenPidContainer_t m_children;
         std::mutex m_childrenContainerMutex;
         bool m_bStarted;
-        boost::asio::io_service m_UI_io_service;
-        boost::asio::ip::tcp::endpoint m_UI_end_point;
         UIConnectionManagerPtr_t m_UIConnectionMng;
         boost::thread_group m_workerThreads;
 

--- a/dds-agent/src/UIConnectionManager.cpp
+++ b/dds-agent/src/UIConnectionManager.cpp
@@ -9,9 +9,8 @@ using namespace std;
 using namespace dds;
 using namespace MiscCommon;
 
-CUIConnectionManager::CUIConnectionManager(boost::asio::io_service& _io_service,
-                                           boost::asio::ip::tcp::endpoint& _endpoint)
-    : CConnectionManagerImpl<CUIChannel, CUIConnectionManager>(_io_service, _endpoint)
+CUIConnectionManager::CUIConnectionManager()
+    : CConnectionManagerImpl<CUIChannel, CUIConnectionManager>(0, 0, false)
 {
 }
 
@@ -19,7 +18,7 @@ CUIConnectionManager::~CUIConnectionManager()
 {
 }
 
-void CUIConnectionManager::_createInfoFile(size_t _port) const
+void CUIConnectionManager::_createInfoFile(const vector<size_t>& _ports) const
 {
     const string sAgntCfg(CUserDefaults::instance().getAgentInfoFileLocation());
     LOG(MiscCommon::info) << "Creating the agent info file: " << sAgntCfg;
@@ -36,10 +35,13 @@ void CUIConnectionManager::_createInfoFile(size_t _port) const
     string srvUser;
     MiscCommon::get_cuser_name(&srvUser);
 
-    f << "[agent]\n"
-      << "host=" << srvHost << "\n"
-      << "user=" << srvUser << "\n"
-      << "port=" << _port << "\n" << endl;
+    if (_ports.size() > 0)
+    {
+        f << "[agent]\n"
+          << "host=" << srvHost << "\n"
+          << "user=" << srvUser << "\n"
+          << "port=" << _ports[0] << "\n" << endl;
+    }
 }
 
 void CUIConnectionManager::_deleteInfoFile() const

--- a/dds-agent/src/UIConnectionManager.h
+++ b/dds-agent/src/UIConnectionManager.h
@@ -18,7 +18,7 @@ namespace dds
     class CUIConnectionManager : public CConnectionManagerImpl<CUIChannel, CUIConnectionManager>
     {
       public:
-        CUIConnectionManager(boost::asio::io_service& _io_service, boost::asio::ip::tcp::endpoint& _endpoint);
+        CUIConnectionManager();
         virtual ~CUIConnectionManager();
 
       public:
@@ -29,7 +29,7 @@ namespace dds
         void _stop()
         {
         }
-        void _createInfoFile(size_t _port) const;
+        void _createInfoFile(const std::vector<size_t>& _ports) const;
         void _deleteInfoFile() const;
         void setCommanderChannel(CCommanderChannel::weakConnectionPtr_t _channel)
         {

--- a/dds-commander/src/ConnectionManager.h
+++ b/dds-commander/src/ConnectionManager.h
@@ -23,9 +23,7 @@ namespace dds
                                public std::enable_shared_from_this<CConnectionManager>
     {
       public:
-        CConnectionManager(const SOptions_t& _options,
-                           boost::asio::io_service& _io_service,
-                           boost::asio::ip::tcp::endpoint& _endpoint);
+        CConnectionManager(const SOptions_t& _options);
 
         ~CConnectionManager();
 
@@ -35,7 +33,7 @@ namespace dds
         void _stop()
         {
         }
-        void _createInfoFile(size_t _port) const;
+        void _createInfoFile(const std::vector<size_t>& _ports) const;
         void _deleteInfoFile() const;
 
       private:

--- a/dds-commander/src/main.cpp
+++ b/dds-commander/src/main.cpp
@@ -98,16 +98,7 @@ int main(int argc, char* argv[])
         {
             CPIDFile pidfile(pidfile_name, ::getpid());
 
-            boost::asio::io_service io_service;
-            const CUserDefaults& userDefaults = CUserDefaults::instance();
-            // get a free port from a given range
-            int nSrvPort =
-                MiscCommon::INet::get_free_port(userDefaults.getOptions().m_server.m_ddsCommanderPortRangeMin,
-                                                userDefaults.getOptions().m_server.m_ddsCommanderPortRangeMax);
-
-            tcp::endpoint endpoint(tcp::v4(), nSrvPort);
-
-            shared_ptr<CConnectionManager> server = make_shared<CConnectionManager>(options, io_service, endpoint);
+            shared_ptr<CConnectionManager> server = make_shared<CConnectionManager>(options);
             server->start();
         }
         catch (exception& e)

--- a/dds-info/src/main.cpp
+++ b/dds-info/src/main.cpp
@@ -46,8 +46,8 @@ int main(int argc, char* argv[])
     {
         string sHost;
         string sPort;
-        // Process server info file.
-        findCommanderServer(&sHost, &sPort);
+        // We connect to UI commander channel.
+        findCommanderUI(&sHost, &sPort);
 
         boost::asio::io_service io_service;
 

--- a/dds-key-value-lib/src/AgentChannel.cpp
+++ b/dds-key-value-lib/src/AgentChannel.cpp
@@ -38,6 +38,12 @@ bool CAgentChannel::on_cmdSIMPLE_MSG(SCommandAttachmentImpl<cmdSIMPLE_MSG>::ptr_
             if (m_syncHelper == nullptr)
                 throw invalid_argument("syncHelper is NULL");
             // m_syncHelper->m_cvUpdateKey.notify_all();
+            if (_attachment->m_msgSeverity == MiscCommon::error)
+            {
+                if (m_syncHelper == nullptr)
+                    throw invalid_argument("syncHelper is NULL");
+                m_syncHelper->m_errorSig(_attachment->m_sMsg);
+            }
             break;
         default:
             LOG(debug) << "Received command cmdSIMPLE_MSG does not have a listener";

--- a/dds-key-value-lib/src/KeyValue.cpp
+++ b/dds-key-value-lib/src/KeyValue.cpp
@@ -48,3 +48,18 @@ void CKeyValue::unsubscribe()
     LOG(info) << "unsubscribing from key notification events.";
     CKeyValueGuard::instance().disconnect();
 }
+
+void CKeyValue::subscribeError(errorSignal_t::slot_function_type _subscriber)
+{
+    CKeyValueGuard::instance().initLock();
+    CKeyValueGuard::instance().initAgentConnection();
+    LOG(info) << "User process is waiting error messages.";
+
+    connection_t connection = CKeyValueGuard::instance().connectError(_subscriber);
+}
+
+void CKeyValue::unsubscribeError()
+{
+    LOG(info) << "unsubscribing from error message notifications";
+    CKeyValueGuard::instance().disconnectError();
+}

--- a/dds-key-value-lib/src/KeyValue.h
+++ b/dds-key-value-lib/src/KeyValue.h
@@ -19,6 +19,7 @@ namespace dds
       public:
         typedef std::map<std::string, std::string> valuesMap_t;
         typedef boost::signals2::signal<void(const std::string&, const std::string&)> signal_t;
+        typedef boost::signals2::signal<void(const std::string&)> errorSignal_t;
         typedef boost::signals2::connection connection_t;
 
       public:
@@ -30,6 +31,9 @@ namespace dds
 
         void subscribe(signal_t::slot_function_type _subscriber);
         void unsubscribe();
+
+        void subscribeError(errorSignal_t::slot_function_type _subscriber);
+        void unsubscribeError();
     };
 }
 

--- a/dds-key-value-lib/src/KeyValueGuard.h
+++ b/dds-key-value-lib/src/KeyValueGuard.h
@@ -23,6 +23,7 @@
 namespace dds
 {
     typedef boost::signals2::signal<void(const std::string&, const std::string&)> signal_t;
+    typedef boost::signals2::signal<void(const std::string&)> errorSignal_t;
     typedef boost::signals2::connection connection_t;
     typedef std::shared_ptr<boost::interprocess::named_mutex> sharedMemoryMutexPtr_t;
     typedef std::shared_ptr<boost::interprocess::managed_shared_memory> managedSharedMemoryPtr_t;
@@ -35,6 +36,7 @@ namespace dds
     struct SSyncHelper
     {
         signal_t m_updateSig;
+        errorSignal_t m_errorSig;
     };
 
     class CKeyValueGuard
@@ -65,6 +67,14 @@ namespace dds
         void disconnect()
         {
             return m_syncHelper.m_updateSig.disconnect_all_slots();
+        }
+        connection_t connectError(errorSignal_t::slot_function_type _subscriber)
+        {
+            return m_syncHelper.m_errorSig.connect(_subscriber);
+        }
+        void disconnectError()
+        {
+            return m_syncHelper.m_errorSig.disconnect_all_slots();
         }
         static void clean();
 

--- a/dds-submit/src/main.cpp
+++ b/dds-submit/src/main.cpp
@@ -40,8 +40,8 @@ int main(int argc, char* argv[])
     string sPort;
     try
     {
-        // Process server info file.
-        findCommanderServer(&sHost, &sPort);
+        // We want to connect to commnader's UI channel
+        findCommanderUI(&sHost, &sPort);
     }
     catch (exception& e)
     {

--- a/dds-test/src/main.cpp
+++ b/dds-test/src/main.cpp
@@ -44,8 +44,8 @@ int main(int argc, char* argv[])
     string sPort;
     try
     {
-        // Process server info file.
-        findCommanderServer(&sHost, &sPort);
+        // We want to connect to commnader's UI channel
+        findCommanderUI(&sHost, &sPort);
     }
     catch (exception& e)
     {

--- a/dds-topology/src/main.cpp
+++ b/dds-topology/src/main.cpp
@@ -58,8 +58,8 @@ int main(int argc, char* argv[])
     string sPort;
     try
     {
-        // Process server info file.
-        findCommanderServer(&sHost, &sPort);
+        // We want to connect to commnader's UI channel
+        findCommanderUI(&sHost, &sPort);
     }
     catch (exception& e)
     {


### PR DESCRIPTION
Added: CConnectionManagerImpl extended to be able to support second UI channel if required.
Added: dds-commander: opens now two ports - one for UI communications and one for the rest.
Modified: dds-info, ddd-agent-cmd, ddd-submit, ddd-test, ddd-topology connect now to DDS commanders UI channel.