### PR TITLE
GH-99: statistics accumulation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(USER_DEFAULTS_CFG_VERSION "0.2")
 # we need cmake v2.8.11+ in order to use target_include_directories
 cmake_minimum_required( VERSION 2.8.11 FATAL_ERROR )
 
+
 # Version
 #
 # take the version string from git and write it to a version file
@@ -52,6 +53,7 @@ option(BUILD_dds-agent-cmd "Build dds-agent-cmd" ON)
 option(BUILD_dds-test "Build dds-test" ON)
 option(BUILD_dds-key-value-lib "Build dds-key-value library" ON)
 option(BUILD_dds-tutorials "Build dds-tutorials" ON)
+option(BUILD_dds-stat "Build dds-stat" ON)
 #
 # Custom targets
 #
@@ -93,7 +95,7 @@ set(IS_SET_DDS_INSTALL_PREFIX 1 CACHE INTERNAL "")
 #
 # Where to lookup modules
 #
-set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}; ${CMAKE_SOURCE_DIR}/cmake")
+set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR};${CMAKE_SOURCE_DIR}/cmake")
 #
 # MiscCommon location
 #
@@ -254,6 +256,12 @@ if(BUILD_dds-tutorials)
     message(STATUS "Build dds-tutorials - YES")
     add_subdirectory ( dds-tutorials )
 endif(BUILD_dds-tutorials)
+
+# dds-stat
+if(BUILD_dds-stat)
+    message(STATUS "Build dds-stat - YES")
+    add_subdirectory ( dds-stat )
+endif(BUILD_dds-stat)
 
 #
 # Install

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,7 +6,10 @@ Added: Give users a possibility to specify task requirement based on worker node
 Fixed: git error when using out of source builds (GH-85)    
 Fixed: a class name lookup issues, which could result in unpredictable behavior during run-time (agent and key-value-lib had     classes with the same name and same header protection).    
 Fixed: check DDS_LOCATION before agent start. (GH-98)   
-Added: extend error message in case if a worker package is missing. (GH-89)    
+Added: extend error message in case if a worker package is missing. (GH-89)   
+Added: statistics accumulation: message size, message queue size for read and write operations is accumulated. (GH-99)   
+Added: new dds-stat command is introduced with possible options: enable, disable and get for statistics accumulation. (GH-99)    
+Fixed: since Mac OS 10.11 (El Capitan) DYLD_LIBRARY_PATH is not exported in the subshell environment. We explicitly set DYLD_LIBRARY_PATH to the libraries directory.   
 
 ### dds-key-value
 Fixed: Forward sys. signals to the calling process giving it a chance to execute its handler if needed. (GH-97)    

--- a/dds-commander/src/AgentChannel.cpp
+++ b/dds-commander/src/AgentChannel.cpp
@@ -226,3 +226,20 @@ bool CAgentChannel::on_cmdSET_TOPOLOGY(SCommandAttachmentImpl<cmdSET_TOPOLOGY>::
 {
     return false;
 }
+
+bool CAgentChannel::on_cmdENABLE_STAT(
+    protocol_api::SCommandAttachmentImpl<protocol_api::cmdENABLE_STAT>::ptr_t _attachment)
+{
+    return false;
+}
+
+bool CAgentChannel::on_cmdDISABLE_STAT(
+    protocol_api::SCommandAttachmentImpl<protocol_api::cmdDISABLE_STAT>::ptr_t _attachment)
+{
+    return false;
+}
+
+bool CAgentChannel::on_cmdGET_STAT(protocol_api::SCommandAttachmentImpl<protocol_api::cmdGET_STAT>::ptr_t _attachment)
+{
+    return false;
+}

--- a/dds-commander/src/AgentChannel.h
+++ b/dds-commander/src/AgentChannel.h
@@ -87,6 +87,11 @@ namespace dds
             MESSAGE_HANDLER(cmdWATCHDOG_HEARTBEAT, on_cmdWATCHDOG_HEARTBEAT)
             MESSAGE_HANDLER(cmdGET_PROP_LIST, on_cmdGET_PROP_LIST)
             MESSAGE_HANDLER(cmdGET_PROP_VALUES, on_cmdGET_PROP_VALUES)
+            // Statistics commands
+            MESSAGE_HANDLER(cmdENABLE_STAT, on_cmdENABLE_STAT)
+            MESSAGE_HANDLER(cmdDISABLE_STAT, on_cmdDISABLE_STAT)
+            MESSAGE_HANDLER(cmdGET_STAT, on_cmdGET_STAT)
+
             END_MSG_MAP()
 
           public:
@@ -160,6 +165,11 @@ namespace dds
                 protocol_api::SCommandAttachmentImpl<protocol_api::cmdGET_PROP_VALUES>::ptr_t _attachment);
             bool on_cmdSET_TOPOLOGY(
                 protocol_api::SCommandAttachmentImpl<protocol_api::cmdSET_TOPOLOGY>::ptr_t _attachment);
+            bool on_cmdENABLE_STAT(
+                protocol_api::SCommandAttachmentImpl<protocol_api::cmdENABLE_STAT>::ptr_t _attachment);
+            bool on_cmdDISABLE_STAT(
+                protocol_api::SCommandAttachmentImpl<protocol_api::cmdDISABLE_STAT>::ptr_t _attachment);
+            bool on_cmdGET_STAT(protocol_api::SCommandAttachmentImpl<protocol_api::cmdGET_STAT>::ptr_t _attachment);
 
             std::string _remoteEndIDString()
             {

--- a/dds-commander/src/ConnectionManager.cpp
+++ b/dds-commander/src/ConnectionManager.cpp
@@ -40,6 +40,7 @@ namespace fs = boost::filesystem;
 
 CConnectionManager::CConnectionManager(const SOptions_t& _options)
     : CConnectionManagerImpl<CAgentChannel, CConnectionManager>(20000, 22000, true)
+    , m_statEnabled(false)
 {
     LOG(info) << "CConnectionManager constructor";
 }
@@ -99,9 +100,11 @@ void CConnectionManager::_start()
 
 void CConnectionManager::newClientCreated(CAgentChannel::connectionPtr_t _newClient)
 {
+    _newClient->setStatEnabled(m_statEnabled);
+
     // Subscribe on protocol messages
-    function<bool(SCommandAttachmentImpl<cmdGET_LOG>::ptr_t _attachment, CAgentChannel * _channel)> fGET_LOG = [this](
-        SCommandAttachmentImpl<cmdGET_LOG>::ptr_t _attachment, CAgentChannel* _channel) -> bool
+    function<bool(SCommandAttachmentImpl<cmdGET_LOG>::ptr_t _attachment, CAgentChannel * _channel)> fGET_LOG =
+        [this](SCommandAttachmentImpl<cmdGET_LOG>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdGET_LOG(_attachment, getWeakPtr(_channel));
     };
@@ -116,39 +119,39 @@ void CConnectionManager::newClientCreated(CAgentChannel::connectionPtr_t _newCli
     _newClient->registerMessageHandler<cmdBINARY_ATTACHMENT_RECEIVED>(fBINARY_ATTACHMENT_RECEIVED);
 
     function<bool(SCommandAttachmentImpl<cmdGET_AGENTS_INFO>::ptr_t _attachment, CAgentChannel * _channel)>
-        fGET_AGENTS_INFO = [this](SCommandAttachmentImpl<cmdGET_AGENTS_INFO>::ptr_t _attachment,
-                                  CAgentChannel* _channel) -> bool
+        fGET_AGENTS_INFO =
+            [this](SCommandAttachmentImpl<cmdGET_AGENTS_INFO>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdGET_AGENTS_INFO(_attachment, getWeakPtr(_channel));
     };
     _newClient->registerMessageHandler<cmdGET_AGENTS_INFO>(fGET_AGENTS_INFO);
 
-    function<bool(SCommandAttachmentImpl<cmdSUBMIT>::ptr_t _attachment, CAgentChannel * _channel)> fSUBMIT = [this](
-        SCommandAttachmentImpl<cmdSUBMIT>::ptr_t _attachment, CAgentChannel* _channel) -> bool
+    function<bool(SCommandAttachmentImpl<cmdSUBMIT>::ptr_t _attachment, CAgentChannel * _channel)> fSUBMIT =
+        [this](SCommandAttachmentImpl<cmdSUBMIT>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdSUBMIT(_attachment, getWeakPtr(_channel));
     };
     _newClient->registerMessageHandler<cmdSUBMIT>(fSUBMIT);
 
     function<bool(SCommandAttachmentImpl<cmdACTIVATE_AGENT>::ptr_t _attachment, CAgentChannel * _channel)>
-        fACTIVATE_AGENT = [this](SCommandAttachmentImpl<cmdACTIVATE_AGENT>::ptr_t _attachment,
-                                 CAgentChannel* _channel) -> bool
+        fACTIVATE_AGENT =
+            [this](SCommandAttachmentImpl<cmdACTIVATE_AGENT>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdACTIVATE_AGENT(_attachment, getWeakPtr(_channel));
     };
     _newClient->registerMessageHandler<cmdACTIVATE_AGENT>(fACTIVATE_AGENT);
 
     function<bool(SCommandAttachmentImpl<cmdSTOP_USER_TASK>::ptr_t _attachment, CAgentChannel * _channel)>
-        fSTOP_USER_TASK = [this](SCommandAttachmentImpl<cmdSTOP_USER_TASK>::ptr_t _attachment,
-                                 CAgentChannel* _channel) -> bool
+        fSTOP_USER_TASK =
+            [this](SCommandAttachmentImpl<cmdSTOP_USER_TASK>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdSTOP_USER_TASK(_attachment, getWeakPtr(_channel));
     };
     _newClient->registerMessageHandler<cmdSTOP_USER_TASK>(fSTOP_USER_TASK);
 
     function<bool(SCommandAttachmentImpl<cmdTRANSPORT_TEST>::ptr_t _attachment, CAgentChannel * _channel)>
-        fTRANSPORT_TEST = [this](SCommandAttachmentImpl<cmdTRANSPORT_TEST>::ptr_t _attachment,
-                                 CAgentChannel* _channel) -> bool
+        fTRANSPORT_TEST =
+            [this](SCommandAttachmentImpl<cmdTRANSPORT_TEST>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdTRANSPORT_TEST(_attachment, getWeakPtr(_channel));
     };
@@ -169,24 +172,24 @@ void CConnectionManager::newClientCreated(CAgentChannel::connectionPtr_t _newCli
     _newClient->registerMessageHandler<cmdUPDATE_KEY>(fUPDATE_KEY);
 
     function<bool(SCommandAttachmentImpl<cmdUSER_TASK_DONE>::ptr_t _attachment, CAgentChannel * _channel)>
-        fUSER_TASK_DONE = [this](SCommandAttachmentImpl<cmdUSER_TASK_DONE>::ptr_t _attachment,
-                                 CAgentChannel* _channel) -> bool
+        fUSER_TASK_DONE =
+            [this](SCommandAttachmentImpl<cmdUSER_TASK_DONE>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdUSER_TASK_DONE(_attachment, getWeakPtr(_channel));
     };
     _newClient->registerMessageHandler<cmdUSER_TASK_DONE>(fUSER_TASK_DONE);
 
     function<bool(SCommandAttachmentImpl<cmdGET_PROP_LIST>::ptr_t _attachment, CAgentChannel * _channel)>
-        fGET_PROP_LIST = [this](SCommandAttachmentImpl<cmdGET_PROP_LIST>::ptr_t _attachment,
-                                CAgentChannel* _channel) -> bool
+        fGET_PROP_LIST =
+            [this](SCommandAttachmentImpl<cmdGET_PROP_LIST>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdGET_PROP_LIST(_attachment, getWeakPtr(_channel));
     };
     _newClient->registerMessageHandler<cmdGET_PROP_LIST>(fGET_PROP_LIST);
 
     function<bool(SCommandAttachmentImpl<cmdGET_PROP_VALUES>::ptr_t _attachment, CAgentChannel * _channel)>
-        fGET_PROP_VALUES = [this](SCommandAttachmentImpl<cmdGET_PROP_VALUES>::ptr_t _attachment,
-                                  CAgentChannel* _channel) -> bool
+        fGET_PROP_VALUES =
+            [this](SCommandAttachmentImpl<cmdGET_PROP_VALUES>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdGET_PROP_VALUES(_attachment, getWeakPtr(_channel));
     };
@@ -199,12 +202,33 @@ void CConnectionManager::newClientCreated(CAgentChannel::connectionPtr_t _newCli
     };
     _newClient->registerMessageHandler<cmdSET_TOPOLOGY>(fSET_TOPOLOGY);
 
-    function<bool(SCommandAttachmentImpl<cmdREPLY_ID>::ptr_t _attachment, CAgentChannel * _channel)> fREPLY_ID = [this](
-        SCommandAttachmentImpl<cmdREPLY_ID>::ptr_t _attachment, CAgentChannel* _channel) -> bool
+    function<bool(SCommandAttachmentImpl<cmdREPLY_ID>::ptr_t _attachment, CAgentChannel * _channel)> fREPLY_ID =
+        [this](SCommandAttachmentImpl<cmdREPLY_ID>::ptr_t _attachment, CAgentChannel* _channel) -> bool
     {
         return this->on_cmdREPLY_ID(_attachment, getWeakPtr(_channel));
     };
     _newClient->registerMessageHandler<cmdREPLY_ID>(fREPLY_ID);
+
+    function<bool(SCommandAttachmentImpl<cmdENABLE_STAT>::ptr_t _attachment, CAgentChannel * _channel)> fENABLE_STAT =
+        [this](SCommandAttachmentImpl<cmdENABLE_STAT>::ptr_t _attachment, CAgentChannel* _channel) -> bool
+    {
+        return this->on_cmdENABLE_STAT(_attachment, getWeakPtr(_channel));
+    };
+    _newClient->registerMessageHandler<cmdENABLE_STAT>(fENABLE_STAT);
+
+    function<bool(SCommandAttachmentImpl<cmdDISABLE_STAT>::ptr_t _attachment, CAgentChannel * _channel)> fDISABLE_STAT =
+        [this](SCommandAttachmentImpl<cmdDISABLE_STAT>::ptr_t _attachment, CAgentChannel* _channel) -> bool
+    {
+        return this->on_cmdDISABLE_STAT(_attachment, getWeakPtr(_channel));
+    };
+    _newClient->registerMessageHandler<cmdDISABLE_STAT>(fDISABLE_STAT);
+
+    function<bool(SCommandAttachmentImpl<cmdGET_STAT>::ptr_t _attachment, CAgentChannel * _channel)> fGET_STAT =
+        [this](SCommandAttachmentImpl<cmdGET_STAT>::ptr_t _attachment, CAgentChannel* _channel) -> bool
+    {
+        return this->on_cmdGET_STAT(_attachment, getWeakPtr(_channel));
+    };
+    _newClient->registerMessageHandler<cmdGET_STAT>(fGET_STAT);
 }
 
 void CConnectionManager::_createInfoFile(const vector<size_t>& _ports) const
@@ -1070,4 +1094,105 @@ uint64_t CConnectionManager::getAgentId()
         }
     } while (true);
     return 0;
+}
+
+void CConnectionManager::enableDisableStatForChannels(bool _enable)
+{
+    CAgentChannel::weakConnectionPtrVector_t channels(getChannels());
+    //                                                      [](CAgentChannel::connectionPtr_t _v)
+    //                    {
+    //                        return (_v->getChannelType() == EChannelType::AGENT && _v->started());
+    //                    }));
+
+    for (const auto& v : channels)
+    {
+        if (v.expired())
+            continue;
+        auto ptr = v.lock();
+
+        ptr->setStatEnabled(_enable);
+    }
+
+    m_statEnabled = _enable;
+}
+
+bool CConnectionManager::on_cmdENABLE_STAT(
+    protocol_api::SCommandAttachmentImpl<protocol_api::cmdENABLE_STAT>::ptr_t _attachment,
+    CAgentChannel::weakConnectionPtr_t _channel)
+{
+    auto p = _channel.lock();
+    try
+    {
+        enableDisableStatForChannels(true);
+
+        p->pushMsg<cmdSIMPLE_MSG>(
+            SSimpleMsgCmd("Statistics is enabled on DDS commander server", MiscCommon::info, cmdENABLE_STAT));
+    }
+    catch (exception& _e)
+    {
+        p->pushMsg<cmdSIMPLE_MSG>(SSimpleMsgCmd(_e.what(), fatal, cmdENABLE_STAT));
+    }
+
+    return true;
+}
+
+bool CConnectionManager::on_cmdDISABLE_STAT(
+    protocol_api::SCommandAttachmentImpl<protocol_api::cmdDISABLE_STAT>::ptr_t _attachment,
+    CAgentChannel::weakConnectionPtr_t _channel)
+{
+    auto p = _channel.lock();
+    try
+    {
+        enableDisableStatForChannels(false);
+
+        p->pushMsg<cmdSIMPLE_MSG>(
+            SSimpleMsgCmd("Statistics is disabled on DDS commander server", MiscCommon::info, cmdDISABLE_STAT));
+    }
+    catch (exception& _e)
+    {
+        p->pushMsg<cmdSIMPLE_MSG>(SSimpleMsgCmd(_e.what(), fatal, cmdDISABLE_STAT));
+    }
+
+    return true;
+}
+
+bool CConnectionManager::on_cmdGET_STAT(
+    protocol_api::SCommandAttachmentImpl<protocol_api::cmdGET_STAT>::ptr_t _attachment,
+    CAgentChannel::weakConnectionPtr_t _channel)
+{
+    auto p = _channel.lock();
+    try
+    {
+        CAgentChannel::weakConnectionPtrVector_t channels(getChannels());
+        //        [](CAgentChannel::connectionPtr_t _v)
+        //                        {
+        //                            return (_v->getChannelType() == EChannelType::AGENT && _v->started());
+        //                        }));
+
+        SReadStat readStat;
+        SWriteStat writeStat;
+
+        for (const auto& v : channels)
+        {
+            if (v.expired())
+                continue;
+            auto ptr = v.lock();
+
+            readStat.addFromStat(ptr->getReadStat());
+            writeStat.addFromStat(ptr->getWriteStat());
+        }
+
+        addDisconnectedChannelsStatToStat(readStat, writeStat);
+
+        stringstream ss;
+        ss << "Number of active channels: " << channels.size() << endl << readStat.toString() << writeStat.toString();
+
+        p->pushMsg<cmdSIMPLE_MSG>(SSimpleMsgCmd(ss.str(), MiscCommon::info, cmdGET_STAT));
+    }
+    catch (exception& _e)
+    {
+        p->pushMsg<cmdSIMPLE_MSG>(SSimpleMsgCmd(_e.what(), fatal, cmdGET_STAT));
+    }
+
+    return true;
 }

--- a/dds-commander/src/ConnectionManager.h
+++ b/dds-commander/src/ConnectionManager.h
@@ -75,9 +75,18 @@ namespace dds
                 CAgentChannel::weakConnectionPtr_t _channel);
             bool on_cmdREPLY_ID(protocol_api::SCommandAttachmentImpl<protocol_api::cmdREPLY_ID>::ptr_t _attachment,
                                 CAgentChannel::weakConnectionPtr_t _channel);
+            bool on_cmdENABLE_STAT(
+                protocol_api::SCommandAttachmentImpl<protocol_api::cmdENABLE_STAT>::ptr_t _attachment,
+                CAgentChannel::weakConnectionPtr_t _channel);
+            bool on_cmdDISABLE_STAT(
+                protocol_api::SCommandAttachmentImpl<protocol_api::cmdDISABLE_STAT>::ptr_t _attachment,
+                CAgentChannel::weakConnectionPtr_t _channel);
+            bool on_cmdGET_STAT(protocol_api::SCommandAttachmentImpl<protocol_api::cmdGET_STAT>::ptr_t _attachment,
+                                CAgentChannel::weakConnectionPtr_t _channel);
 
           private:
             uint64_t getAgentId();
+            void enableDisableStatForChannels(bool _enable);
 
             CGetLogChannelInfo m_getLog;
             CTestChannelInfo m_transportTest;
@@ -97,6 +106,9 @@ namespace dds
             // Set stores all generated agent ID to be able to detect collisions
             std::set<uint64_t> m_agentIdSet;
             std::mutex m_agentIdSetMutex;
+
+            // Statistic on/off flag
+            bool m_statEnabled;
         };
     }
 }

--- a/dds-protocol-lib/CMakeLists.txt
+++ b/dds-protocol-lib/CMakeLists.txt
@@ -31,6 +31,7 @@ set( SOURCE_FILES
 	./src/UserTaskDoneCmd.cpp
 	./src/GetPropValuesCmd.cpp
 	./src/SetTopologyCmd.cpp
+	./src/StatImpl.cpp
 )
 
 set( SRC_HDRS
@@ -59,6 +60,7 @@ set( SRC_HDRS
 	./src/UserTaskDoneCmd.h
 	./src/GetPropValuesCmd.h
 	./src/SetTopologyCmd.h
+	./src/StatImpl.h
 )
 
 include_directories(
@@ -79,6 +81,8 @@ endif (CMAKE_GENERATOR STREQUAL "Xcode")
 target_link_libraries (
 	dds-protocol-lib
 	${Boost_SYSTEM_LIBRARY}
+    ${Boost_LOG_LIBRARY}
+    ${Boost_LOG_SETUP_LIBRARY}
 )
 
 target_include_directories(dds-protocol-lib

--- a/dds-protocol-lib/src/ProtocolCommands.h
+++ b/dds-protocol-lib/src/ProtocolCommands.h
@@ -56,7 +56,10 @@ namespace dds
             cmdGET_PROP_VALUES,
             cmdPROGRESS, // attachment: SProgressCmd
             cmdWATCHDOG_HEARTBEAT,
-            cmdSET_TOPOLOGY // attachment: SSetTopologyCmd
+            cmdSET_TOPOLOGY, // attachment: SSetTopologyCmd
+            cmdENABLE_STAT,
+            cmdDISABLE_STAT,
+            cmdGET_STAT
         };
 
         static std::map<uint16_t, std::string> g_cmdToString{
@@ -91,7 +94,10 @@ namespace dds
             { cmdGET_PROP_VALUES, NAME_TO_STRING(cmdGET_PROP_VALUES) },
             { cmdPROGRESS, NAME_TO_STRING(cmdPROGRESS) },
             { cmdWATCHDOG_HEARTBEAT, NAME_TO_STRING(cmdWATCHDOG_HEARTBEAT) },
-            { cmdSET_TOPOLOGY, NAME_TO_STRING(cmdSET_TOPOLOGY) }
+            { cmdSET_TOPOLOGY, NAME_TO_STRING(cmdSET_TOPOLOGY) },
+            { cmdENABLE_STAT, NAME_TO_STRING(cmdENABLE_STAT) },
+            { cmdDISABLE_STAT, NAME_TO_STRING(cmdDISABLE_STAT) },
+            { cmdGET_STAT, NAME_TO_STRING(cmdGET_STAT) }
         };
     }
 }

--- a/dds-protocol-lib/src/StatImpl.cpp
+++ b/dds-protocol-lib/src/StatImpl.cpp
@@ -1,0 +1,242 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+#include "StatImpl.h"
+#include "Logger.h"
+#include "ProtocolCommands.h"
+
+#include <sstream>
+
+// using namespace std;
+using namespace dds;
+using namespace dds::protocol_api;
+using namespace std;
+using namespace MiscCommon;
+
+std::string formatBytes(double _size)
+{
+    stringstream ss;
+
+    static double c_k = 1. / 1024.0;
+    static double c_m = 1. / 1048576.0;
+    static double c_g = 1. / 1073741824.0;
+    static double c_t = 1. / 1099511627776.0;
+
+    double b = _size;
+    double k = _size * c_k;
+    double m = _size * c_m;
+    double g = _size * c_g;
+    double t = _size * c_t;
+
+    if (t > 1)
+    {
+        ss << fixed << setprecision(2) << t << " TB";
+    }
+    else if (g > 1)
+    {
+        ss << fixed << setprecision(2) << g << " GB";
+    }
+    else if (m > 1)
+    {
+        ss << fixed << setprecision(2) << m << " MB";
+    }
+    else if (k > 1)
+    {
+        ss << fixed << setprecision(2) << k << " KB";
+    }
+    else
+    {
+        ss << (uint64_t)b << " B";
+    }
+    return ss.str();
+}
+
+std::string stringFromStat(const string _title, const SStatParams& _statParams, const statParamsMap_t& _statParamsMap)
+{
+    stringstream ss;
+
+    int colwcmd = 33;
+    int colw = 15;
+    int totalw = colwcmd + 4 * colw;
+    ss << setw(totalw) << left << _title << endl;
+    ss << setw(colwcmd) << "cmd" << setw(colw) << "mean" << setw(colw) << "max" << setw(colw) << "sum" << setw(colw)
+       << "count" << endl;
+    for (const auto& v : _statParamsMap)
+    {
+        uint16_t cmd = v.first;
+        const auto& stat = v.second;
+        ss << setw(colwcmd) << g_cmdToString[cmd] << setw(colw) << formatBytes(stat.m_mean) << setw(colw)
+           << formatBytes(stat.m_max) << setw(colw) << formatBytes(stat.m_sum) << setw(colw) << stat.m_count << endl;
+    }
+    ss << setw(colwcmd) << "Total" << setw(colw) << formatBytes(_statParams.m_mean) << setw(colw) << (_statParams.m_max)
+       << setw(colw) << formatBytes(_statParams.m_sum) << setw(colw) << _statParams.m_count << endl;
+
+    return ss.str();
+}
+
+/////////////////////////////////////////
+/// SStatParams
+/////////////////////////////////////////
+void SStatParams::addFromStatParams(const SStatParams& _stat)
+{
+    m_mean = (m_mean == numeric_limits<double>::min()) ? _stat.m_mean : (m_mean + _stat.m_mean) / 2;
+    m_max = std::max(m_max, _stat.m_max);
+    m_count += _stat.m_count;
+    m_sum += _stat.m_sum;
+}
+
+void SStatParams::fillFromAccumulator(const statsAccumulator_t& _accumulator)
+{
+    m_count = boost::accumulators::count(_accumulator);
+    m_mean = (m_count != 0) ? boost::accumulators::mean(_accumulator) : 0;
+    m_max = (m_count != 0) ? boost::accumulators::max(_accumulator) : 0;
+    m_sum = (m_count != 0) ? boost::accumulators::sum(_accumulator) : 0;
+}
+
+/////////////////////////////////////////
+/// SWriteStat
+/////////////////////////////////////////
+void SWriteStat::addFromStat(const dds::protocol_api::SWriteStat& _stat)
+{
+    m_messageBytes.addFromStatParams(_stat.m_messageBytes);
+    m_queueBytes.addFromStatParams(_stat.m_queueBytes);
+    m_queueMessages.addFromStatParams(_stat.m_queueMessages);
+    for (auto& v : _stat.m_messageBytesMap)
+    {
+        m_messageBytesMap[v.first].addFromStatParams(v.second);
+    }
+}
+
+std::string SWriteStat::toString() const
+{
+    stringstream ss;
+    int colw = 12;
+    ss << stringFromStat("Write (message size)", m_messageBytes, m_messageBytesMap) << endl
+       << "Write (message queue size - bytes)" << endl
+       << setw(colw) << "mean" << setw(colw) << "max" << setw(colw) << "sum" << setw(colw) << "count" << endl
+       << setw(colw) << formatBytes(m_queueBytes.m_mean) << setw(colw) << formatBytes(m_queueBytes.m_max) << setw(colw)
+       << formatBytes(m_queueBytes.m_sum) << setw(colw) << m_queueBytes.m_count << endl
+       << endl
+       << "Write (message queue size - messages)" << endl
+       << setw(colw) << "mean" << setw(colw) << "max" << setw(colw) << "sum" << setw(colw) << "count" << endl
+       << setw(colw) << fixed << setprecision(2) << m_queueMessages.m_mean << setw(colw)
+       << (uint64_t)m_queueMessages.m_max << setw(colw) << (uint64_t)m_queueMessages.m_sum << setw(colw)
+       << (uint64_t)m_queueMessages.m_count << endl;
+
+    return ss.str();
+}
+
+/////////////////////////////////////////
+/// CReadStat
+/////////////////////////////////////////
+void SReadStat::addFromStat(const dds::protocol_api::SReadStat& _stat)
+{
+    m_messageBytes.addFromStatParams(_stat.m_messageBytes);
+    for (auto& v : _stat.m_messageBytesMap)
+    {
+        m_messageBytesMap[v.first].addFromStatParams(v.second);
+    }
+}
+
+std::string SReadStat::toString() const
+{
+    stringstream ss;
+
+    ss << stringFromStat("Read (message size)", m_messageBytes, m_messageBytesMap) << endl;
+
+    return ss.str();
+}
+
+/////////////////////////////////////////
+/// CStatImpl
+/////////////////////////////////////////
+SReadStat CStatImpl::getReadStat() const
+{
+    SReadStat local;
+    {
+        std::lock_guard<std::mutex> lock(m_logReadMutex);
+        local.m_messageBytes.fillFromAccumulator(m_readMessageBytesAccumulator);
+        for (const auto& v : m_readMessageBytesAccumulatorMap)
+        {
+            local.m_messageBytesMap[v.first].fillFromAccumulator(v.second);
+        }
+    }
+    return local;
+}
+
+SWriteStat CStatImpl::getWriteStat() const
+{
+    SWriteStat local;
+    {
+        std::lock_guard<std::mutex> lock(m_logWriteMutex);
+        local.m_messageBytes.fillFromAccumulator(m_writeMessageBytesAccumulator);
+        local.m_queueBytes.fillFromAccumulator(m_writeQueueBytesAccumulator);
+        local.m_queueMessages.fillFromAccumulator(m_writeQueueMessagesAccumulator);
+        for (const auto& v : m_writeMessageBytesAccumulatorMap)
+        {
+            local.m_messageBytesMap[v.first].fillFromAccumulator(v.second);
+        }
+    }
+    return local;
+}
+
+void CStatImpl::setStatEnabled(bool _statEnabled)
+{
+    m_statEnabled.store(_statEnabled);
+}
+
+void CStatImpl::logReadMessage(CProtocolMessage::protocolMessagePtr_t _message)
+{
+    if (!m_statEnabled.load())
+        return;
+
+    // Store local copy of message header.
+    // Message can be destroyed or cleared by external functions.
+    SMessageHeader header(_message->header());
+
+    m_io_service.post(
+        [this, header]
+        {
+            std::lock_guard<std::mutex> lock(m_logReadMutex);
+            m_readMessageBytesAccumulator(header.m_len + CProtocolMessage::header_length);
+            m_readMessageBytesAccumulatorMap[header.m_cmd](header.m_len + CProtocolMessage::header_length);
+        });
+}
+
+void CStatImpl::logWriteMessages(const protocolMessagePtrQueue_t& _messageQueue)
+{
+    if (!m_statEnabled.load())
+        return;
+
+    size_t numberOfMessagesInQueue = _messageQueue.size();
+    m_io_service.post([this, numberOfMessagesInQueue]
+                      {
+                          std::lock_guard<std::mutex> lock(m_logWriteMutex);
+                          m_writeQueueMessagesAccumulator(numberOfMessagesInQueue);
+                      });
+
+    uint64_t numberOfBytes = 0;
+    for (const auto& message : _messageQueue)
+    {
+        // Store local copy of message header.
+        // Message can be destroyed or cleared by external functions.
+        SMessageHeader header(message->header());
+
+        numberOfBytes += (header.m_len + CProtocolMessage::header_length);
+
+        m_io_service.post(
+            [this, header]
+            {
+                std::lock_guard<std::mutex> lock(m_logWriteMutex);
+                m_writeMessageBytesAccumulator(header.m_len + CProtocolMessage::header_length);
+                m_writeMessageBytesAccumulatorMap[header.m_cmd](header.m_len + CProtocolMessage::header_length);
+            });
+    }
+
+    m_io_service.post([this, numberOfBytes]
+                      {
+                          std::lock_guard<std::mutex> lock(m_logWriteMutex);
+                          m_writeQueueBytesAccumulator(numberOfBytes);
+                      });
+}

--- a/dds-protocol-lib/src/StatImpl.h
+++ b/dds-protocol-lib/src/StatImpl.h
@@ -1,0 +1,164 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+#ifndef __DDS__StatImpl__
+#define __DDS__StatImpl__
+
+#include <mutex>
+#include <deque>
+#include <atomic>
+#include <map>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#include <boost/asio.hpp>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/max.hpp>
+#include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/sum.hpp>
+#include <boost/accumulators/statistics/count.hpp>
+#pragma clang diagnostic pop
+
+#include "ProtocolMessage.h"
+
+namespace dds
+{
+    namespace protocol_api
+    {
+        typedef boost::accumulators::accumulator_set<double,
+                                                     boost::accumulators::features<boost::accumulators::tag::mean,
+                                                                                   boost::accumulators::tag::max,
+                                                                                   boost::accumulators::tag::count,
+                                                                                   boost::accumulators::tag::sum>>
+            statsAccumulator_t;
+
+        // Maps command to stats accumulator
+        typedef std::map<uint16_t, statsAccumulator_t> statsAccumulatorMap_t;
+
+        struct SStatParams;
+        typedef std::map<uint16_t, SStatParams> statParamsMap_t;
+
+        struct SStatParams
+        {
+            SStatParams()
+                : m_mean(std::numeric_limits<double>::min())
+                , m_max(std::numeric_limits<double>::min())
+                , m_count(0)
+                , m_sum(0)
+            {
+            }
+
+            void fillFromAccumulator(const statsAccumulator_t& _accumulator);
+
+            /// \brief Add statistics from another structure
+            /// \note This function is not thread safe.
+            void addFromStatParams(const SStatParams& _stat);
+
+            /// \brief String representation of the object
+            /// \note This function is not thread safe.
+            std::string toString() const;
+
+            double m_mean;
+            double m_max;
+            double m_count;
+            double m_sum;
+        };
+
+        struct SWriteStat
+        {
+            SWriteStat()
+                : m_messageBytes()
+                , m_queueBytes()
+                , m_queueMessages()
+            {
+            }
+
+            /// \brief Add statistics from another structure
+            /// \note This function is not thread safe.
+            void addFromStat(const SWriteStat& _stat);
+
+            /// \brief String representation of the object
+            /// \note This function is not thread safe.
+            std::string toString() const;
+
+            SStatParams m_messageBytes;
+            SStatParams m_queueBytes;
+            SStatParams m_queueMessages;
+            statParamsMap_t m_messageBytesMap;
+        };
+
+        struct SReadStat
+        {
+            SReadStat()
+                : m_messageBytes()
+            {
+            }
+
+            /// \brief Add statistics from another structure
+            /// \note This function is not thread safe.
+            void addFromStat(const SReadStat& _stat);
+
+            /// \brief String representation of the object
+            /// \note This function is not thread safe.
+            std::string toString() const;
+
+            SStatParams m_messageBytes;
+            statParamsMap_t m_messageBytesMap;
+        };
+
+        class CStatImpl
+        {
+            typedef std::deque<CProtocolMessage::protocolMessagePtr_t> protocolMessagePtrQueue_t;
+
+          public:
+            CStatImpl(boost::asio::io_service& _service)
+                : m_statEnabled(false)
+                , m_logReadMutex()
+                , m_readMessageBytesAccumulator()
+                , m_readMessageBytesAccumulatorMap()
+                , m_logWriteMutex()
+                , m_writeMessageBytesAccumulator()
+                , m_writeQueueBytesAccumulator()
+                , m_writeQueueMessagesAccumulator()
+                , m_writeMessageBytesAccumulatorMap()
+                , m_io_service(_service)
+            {
+            }
+
+            /// \brief Return read statistics
+            SReadStat getReadStat() const;
+
+            /// \brief Return write statistics
+            SWriteStat getWriteStat() const;
+
+            /// \brief Enable/disable statistics accumulation
+            void setStatEnabled(bool _statEnabled);
+
+            // TODO: We have to think if it would be better to use weak_ptr here instead of shared_ptr
+            void logReadMessage(CProtocolMessage::protocolMessagePtr_t _message);
+            void logWriteMessages(const protocolMessagePtrQueue_t& _messageQueue);
+
+          private:
+            // Enable/Disable statistics accumulation
+            std::atomic<bool> m_statEnabled;
+
+            // Read statistics
+            mutable std::mutex m_logReadMutex;
+            statsAccumulator_t m_readMessageBytesAccumulator;
+            statsAccumulatorMap_t m_readMessageBytesAccumulatorMap;
+
+            // Write statistics
+            mutable std::mutex m_logWriteMutex;
+            statsAccumulator_t m_writeMessageBytesAccumulator;
+            statsAccumulator_t m_writeQueueBytesAccumulator;
+            statsAccumulator_t m_writeQueueMessagesAccumulator;
+            statsAccumulatorMap_t m_writeMessageBytesAccumulatorMap;
+
+            boost::asio::io_service& m_io_service;
+        };
+    }
+};
+
+#endif /* defined(__DDS__StatImpl__) */

--- a/dds-stat/CMakeLists.txt
+++ b/dds-stat/CMakeLists.txt
@@ -1,0 +1,76 @@
+# Copyright 2014 GSI, Inc. All rights reserved.
+#
+#
+project( dds-stat )
+
+#
+# Where to lookup modules
+#
+set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}")
+
+#
+# configure files
+# 
+configure_file( ${dds-stat_SOURCE_DIR}/src/version.h.in ${dds-stat_BINARY_DIR}/version.h @ONLY )
+
+#
+# Source files
+#
+set( SOURCE_FILES
+	./src/main.cpp
+	./src/StatChannel.cpp
+)
+
+#
+# Header files
+#
+set( HEADER_FILES
+	./src/Options.h
+	./src/StatChannel.h
+)
+
+include_directories(
+	${dds-stat_BINARY_DIR}
+	${MiscCommon_LOCATION}
+	${Boost_INCLUDE_DIRS} 
+)
+
+#
+# dds-stat executable
+#
+if (CMAKE_GENERATOR STREQUAL "Xcode")
+    add_executable(dds-stat ${SOURCE_FILES} ${HEADER_FILES})
+else (CMAKE_GENERATOR STREQUAL "Xcode")
+    add_executable(dds-stat ${SOURCE_FILES})
+endif (CMAKE_GENERATOR STREQUAL "Xcode")
+
+target_link_libraries (
+	dds-stat
+	dds-user-defaults-lib
+	dds-protocol-lib
+	${Boost_PROGRAM_OPTIONS_LIBRARY}
+	${Boost_SYSTEM_LIBRARY}
+	${Boost_LOG_LIBRARY}
+	${Boost_LOG_SETUP_LIBRARY}
+	${Boost_THREAD_LIBRARY}
+)
+
+target_include_directories(dds-stat
+	PRIVATE
+		$<TARGET_PROPERTY:dds-user-defaults-lib,INTERFACE_INCLUDE_DIRECTORIES>
+	PRIVATE
+		$<TARGET_PROPERTY:dds-protocol-lib,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+install(TARGETS dds-stat DESTINATION bin)
+
+#
+# Unit tests
+#
+#if (BUILD_TESTS)
+#    message (STATUS "Build dds-stat unit tests - YES")
+#    add_subdirectory ( ${dds-stat_SOURCE_DIR}/tests ) 
+#else (BUILD_TESTS)
+#    message (STATUS "Build dds-stat unit tests - NO")
+#endif (BUILD_TESTS)
+

--- a/dds-stat/src/Options.h
+++ b/dds-stat/src/Options.h
@@ -1,0 +1,119 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+#ifndef DDSOPTIONS_H
+#define DDSOPTIONS_H
+//=============================================================================
+// BOOST
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+// DDS
+#include "version.h"
+#include "Res.h"
+#include "ProtocolCommands.h"
+// STD
+#include <string>
+//=============================================================================
+namespace bpo = boost::program_options;
+//=============================================================================
+namespace dds
+{
+    namespace stat_cmd
+    {
+        /// \brief dds-commander's container of options
+        typedef struct SOptions
+        {
+            SOptions()
+                : m_bEnable(false)
+                , m_bDisable(false)
+                , m_bGet(false)
+            {
+            }
+
+            bool m_bEnable;
+            bool m_bDisable;
+            bool m_bGet;
+        } SOptions_t;
+        //=============================================================================
+        inline void PrintVersion()
+        {
+            LOG(MiscCommon::log_stdout) << " v" << PROJECT_VERSION_STRING << "\n"
+                                        << "DDS configuration"
+                                        << " v" << USER_DEFAULTS_CFG_VERSION << "\n" << MiscCommon::g_cszReportBugsAddr;
+        }
+        //=============================================================================
+        // Command line parser
+        inline bool ParseCmdLine(int _argc, char* _argv[], SOptions* _options) throw(std::exception)
+        {
+            if (nullptr == _options)
+                throw std::runtime_error("Internal error: options' container is empty.");
+
+            // Generic options
+            bpo::options_description options("dds-stat options");
+            options.add_options()("help,h", "Produce help message");
+            options.add_options()("version,v", "Version information");
+            options.add_options()(
+                "command",
+                bpo::value<std::string>(),
+                "The command is a name of a dds-stat command."
+                " Can be one of the following: enable, disable and get.\n"
+                "For user's convenience it is allowed to call dds-stat without \"--command\" option"
+                " by just specifying the command name directly, like:\ndds-stat enable or dds-stat get.\n\n"
+                "Commands:\n"
+                "   enable: \tEnable statistics on the commander server.\n"
+                "   disable: \tDisable statistics on the commander server.\n"
+                "   get: \tGet statistics from the commander server.\n");
+
+            //...positional
+            bpo::positional_options_description pd;
+            pd.add("command", 1);
+
+            // Parsing command-line
+            bpo::variables_map vm;
+            bpo::store(bpo::command_line_parser(_argc, _argv).options(options).positional(pd).run(), vm);
+            bpo::notify(vm);
+
+            if (vm.count("help") || vm.empty())
+            {
+                LOG(MiscCommon::log_stdout) << options;
+                return false;
+            }
+            if (vm.count("version"))
+            {
+                PrintVersion();
+                return false;
+            }
+
+            if (vm.count("command"))
+            {
+                std::string cmd = vm["command"].as<std::string>();
+                if (cmd == "enable")
+                {
+                    _options->m_bEnable = true;
+                }
+                else if (cmd == "disable")
+                {
+                    _options->m_bDisable = true;
+                }
+                else if (cmd == "get")
+                {
+                    _options->m_bGet = true;
+                }
+                else
+                {
+                    LOG(MiscCommon::log_stderr) << "unknown command: " << cmd << "\n\n" << options;
+                    return false;
+                }
+            }
+            else
+            {
+                LOG(MiscCommon::log_stderr) << "Nothing to do\n\n" << options;
+                return false;
+            }
+
+            return true;
+        }
+    }
+}
+#endif

--- a/dds-stat/src/StatChannel.cpp
+++ b/dds-stat/src/StatChannel.cpp
@@ -1,0 +1,30 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+
+// DDS
+#include "StatChannel.h"
+
+using namespace MiscCommon;
+using namespace dds;
+using namespace dds::protocol_api;
+using namespace dds::stat_cmd;
+using namespace std;
+
+bool CStatChannel::on_cmdSIMPLE_MSG(SCommandAttachmentImpl<cmdSIMPLE_MSG>::ptr_t _attachment)
+{
+    if (_attachment->m_srcCommand == cmdENABLE_STAT || _attachment->m_srcCommand == cmdDISABLE_STAT ||
+        _attachment->m_srcCommand == cmdGET_STAT)
+    {
+        if (!_attachment->m_sMsg.empty())
+            LOG(log_stdout) << "\n" << _attachment->m_sMsg;
+        stop();
+        return true;
+    }
+
+    if (!_attachment->m_sMsg.empty())
+        LOG(log_stdout) << "Server reports: " << _attachment->m_sMsg;
+
+    return true;
+}

--- a/dds-stat/src/StatChannel.h
+++ b/dds-stat/src/StatChannel.h
@@ -1,0 +1,72 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+
+#ifndef __DDS__StatChannel__
+#define __DDS__StatChannel__
+// DDS
+#include "ClientChannelImpl.h"
+#include "Options.h"
+
+namespace dds
+{
+    namespace stat_cmd
+    {
+        class CStatChannel : public protocol_api::CClientChannelImpl<CStatChannel>
+        {
+            CStatChannel(boost::asio::io_service& _service)
+                : CClientChannelImpl<CStatChannel>(_service, protocol_api::EChannelType::UI)
+            {
+                subscribeOnEvent(protocol_api::EChannelEvents::OnHandshakeOK,
+                                 [this](CStatChannel* _channel)
+                                 {
+                                     if (m_options.m_bEnable)
+                                     {
+                                         pushMsg<protocol_api::cmdENABLE_STAT>();
+                                     }
+                                     else if (m_options.m_bDisable)
+                                     {
+                                         pushMsg<protocol_api::cmdDISABLE_STAT>();
+                                     }
+                                     else if (m_options.m_bGet)
+                                     {
+                                         pushMsg<protocol_api::cmdGET_STAT>();
+                                     }
+                                 });
+
+                subscribeOnEvent(protocol_api::EChannelEvents::OnConnected,
+                                 [this](CStatChannel* _channel)
+                                 {
+                                     LOG(MiscCommon::info) << "Connected to the commander server";
+                                 });
+
+                subscribeOnEvent(protocol_api::EChannelEvents::OnFailedToConnect,
+                                 [this](CStatChannel* _channel)
+                                 {
+                                     LOG(MiscCommon::log_stderr) << "Failed to connect to commander server.";
+                                 });
+            }
+
+            REGISTER_DEFAULT_REMOTE_ID_STRING
+
+          public:
+            BEGIN_MSG_MAP(CStatChannel)
+            MESSAGE_HANDLER(cmdSIMPLE_MSG, on_cmdSIMPLE_MSG)
+            END_MSG_MAP()
+
+            void setOptions(const SOptions& _options)
+            {
+                m_options = _options;
+            }
+
+          private:
+            // Message Handlers
+            bool on_cmdSIMPLE_MSG(protocol_api::SCommandAttachmentImpl<protocol_api::cmdSIMPLE_MSG>::ptr_t _attachment);
+
+          private:
+            SOptions m_options;
+        };
+    }
+}
+#endif

--- a/dds-stat/src/main.cpp
+++ b/dds-stat/src/main.cpp
@@ -1,0 +1,74 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+// DDS
+#include "Process.h"
+#include "ErrorCode.h"
+#include "BOOSTHelper.h"
+#include "UserDefaults.h"
+#include "SysHelper.h"
+#include "StatChannel.h"
+#include "INet.h"
+#include "DDSHelper.h"
+
+using namespace std;
+using namespace MiscCommon;
+using namespace dds;
+using namespace dds::stat_cmd;
+using namespace dds::user_defaults_api;
+using boost::asio::ip::tcp;
+
+//=============================================================================
+int main(int argc, char* argv[])
+{
+    // Command line parser
+    SOptions_t options;
+
+    try
+    {
+        Logger::instance().init(); // Initialize log
+        CUserDefaults::instance(); // Initialize user defaults
+
+        vector<std::string> arguments(argv + 1, argv + argc);
+        ostringstream ss;
+        copy(arguments.begin(), arguments.end(), ostream_iterator<string>(ss, " "));
+        LOG(info) << "Starting with arguments: " << ss.str();
+
+        if (!ParseCmdLine(argc, argv, &options))
+            return EXIT_SUCCESS;
+    }
+    catch (exception& e)
+    {
+        LOG(log_stderr) << e.what();
+        return EXIT_FAILURE;
+    }
+
+    try
+    {
+        string sHost;
+        string sPort;
+        // We connect to UI commander channel.
+        findCommanderUI(&sHost, &sPort);
+
+        boost::asio::io_service io_service;
+
+        boost::asio::ip::tcp::resolver resolver(io_service);
+        boost::asio::ip::tcp::resolver::query query(sHost, sPort);
+
+        boost::asio::ip::tcp::resolver::iterator iterator = resolver.resolve(query);
+
+        CStatChannel::connectionPtr_t client = CStatChannel::makeNew(io_service);
+        client->setOptions(options);
+        client->connect(iterator);
+
+        io_service.run();
+    }
+    catch (exception& e)
+    {
+        LOG(error) << e.what();
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/dds-stat/src/version.h.in
+++ b/dds-stat/src/version.h.in
@@ -1,0 +1,15 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+#ifndef _VERSION_H
+#define _VERSION_H
+
+#define PROJECT_NAME "@PROJECT_NAME@"
+#define PROJECT_VERSION_STRING "@DDS_VERSION@"
+#define USER_DEFAULTS_CFG_VERSION "@USER_DEFAULTS_CFG_VERSION@"
+
+#define INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
+#define INSTALL_PREFIX_TESTS "@CMAKE_INSTALL_PREFIX@/tests"
+#endif
+


### PR DESCRIPTION
Message size, message queue size for read and write operations is accumulated.
New dds-stat command is introduced with possible options: enable, disable and get.
By default statistics is disabled for performance reasons.
To enable statistics accumulation use dds-stat enable.
To get statistics summary from commander use dds-stat get.