### PR TITLE
GH-105: GH-106: GH-107: generalized implementation of DDS commands

### DIFF
--- a/MiscCommon/INet.h
+++ b/MiscCommon/INet.h
@@ -14,10 +14,18 @@
 // STD
 #include <unistd.h>
 #include <stdexcept>
+#include <iterator>
+#include <algorithm>
 // MiscCommon
 #include "ErrorCode.h"
 #include "MiscUtils.h"
 #include "def.h"
+// BOOST
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-register"
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#pragma clang diagnostic pop
 
 /// this macro indicates an invalid status of the socket
 #define INVALID_SOCKET -1
@@ -633,94 +641,6 @@ namespace MiscCommon
         inline uint64_t normalizeWrite<uint64_t>(uint64_t _value)
         {
             return htonll(_value);
-        }
-
-        template <typename T>
-        void readData(T* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos);
-
-        template <>
-        inline void readData<uint16_t>(uint16_t* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
-        {
-            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
-                throw std::invalid_argument("readDataFromContainer");
-
-            *_value = (*_data)[*_nPos];
-            *_value += ((*_data)[++(*_nPos)] << 8);
-
-            ++(*_nPos);
-        }
-
-        template <>
-        inline void readData<uint32_t>(uint32_t* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
-        {
-            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
-                throw std::invalid_argument("readDataFromContainer");
-
-            *_value = (*_data)[*_nPos];
-            *_value += ((*_data)[++(*_nPos)] << 8);
-            *_value += ((*_data)[++(*_nPos)] << 16);
-            *_value += ((*_data)[++(*_nPos)] << 24);
-
-            ++(*_nPos);
-        }
-
-        template <>
-        inline void readData<uint64_t>(uint64_t* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
-        {
-            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
-                throw std::invalid_argument("readDataFromContainer");
-
-            *_value = (*_data)[*_nPos];
-            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 8);
-            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 16);
-            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 24);
-            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 32);
-            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 40);
-            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 48);
-            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 56);
-
-            ++(*_nPos);
-        }
-
-        template <typename T>
-        void pushData(const T& _value, MiscCommon::BYTEVector_t* _data);
-
-        template <>
-        inline void pushData<uint16_t>(const uint16_t& _value, MiscCommon::BYTEVector_t* _data)
-        {
-            if (_data == nullptr)
-                throw std::invalid_argument("pushDataFromContainer");
-
-            _data->push_back(_value & 0xFF);
-            _data->push_back(_value >> 8);
-        }
-
-        template <>
-        inline void pushData<uint32_t>(const uint32_t& _value, MiscCommon::BYTEVector_t* _data)
-        {
-            if (_data == nullptr)
-                throw std::invalid_argument("pushDataFromContainer");
-
-            _data->push_back(_value & 0xFF);
-            _data->push_back((_value >> 8) & 0xFF);
-            _data->push_back((_value >> 16) & 0xFF);
-            _data->push_back((_value >> 24) & 0xFF);
-        }
-
-        template <>
-        inline void pushData<uint64_t>(const uint64_t& _value, MiscCommon::BYTEVector_t* _data)
-        {
-            if (_data == nullptr)
-                throw std::invalid_argument("pushDataFromContainer");
-
-            _data->push_back(_value & 0xFF);
-            _data->push_back((_value >> 8) & 0xFF);
-            _data->push_back((_value >> 16) & 0xFF);
-            _data->push_back((_value >> 24) & 0xFF);
-            _data->push_back((_value >> 32) & 0xFF);
-            _data->push_back((_value >> 40) & 0xFF);
-            _data->push_back((_value >> 48) & 0xFF);
-            _data->push_back((_value >> 56) & 0xFF);
         }
 
         /**

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,10 @@
 # DDS Release Notes
 
 ## v1.2 (Not Yet Released)
+### dds-protocol-lib
+Added: sending of arrays (GH-105)   
+Added: sending of strings (GH-106)   
+Added: generalized implementation of DDS commands (GH-107)   
 
 
 ## v1.0 (2015-11-20)

--- a/dds-protocol-lib/src/AgentsInfoCmd.h
+++ b/dds-protocol-lib/src/AgentsInfoCmd.h
@@ -13,34 +13,17 @@ namespace dds
     {
         struct SAgentsInfoCmd : public SBasicCmd<SAgentsInfoCmd>
         {
-            SAgentsInfoCmd()
-                : m_nActiveAgents(0)
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                return sizeof(m_nActiveAgents) + (m_sListOfAgents.size() + 1);
-            }
+            SAgentsInfoCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SAgentsInfoCmd& _val) const
-            {
-                return (m_nActiveAgents == _val.m_nActiveAgents && m_sListOfAgents == _val.m_sListOfAgents);
-            }
+            bool operator==(const SAgentsInfoCmd& _val) const;
 
-            mutable uint32_t m_nActiveAgents;
+            uint32_t m_nActiveAgents;
             std::string m_sListOfAgents;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SAgentsInfoCmd& _val)
-        {
-            return _stream << _val.m_nActiveAgents;
-        }
-        inline bool operator!=(const SAgentsInfoCmd& _lhs, const SAgentsInfoCmd& _rhs)
-        {
-            return !(_lhs == _rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SAgentsInfoCmd& _val);
+        bool operator!=(const SAgentsInfoCmd& _lhs, const SAgentsInfoCmd& _rhs);
     }
 };
 

--- a/dds-protocol-lib/src/AssignUserTaskCmd.cpp
+++ b/dds-protocol-lib/src/AssignUserTaskCmd.cpp
@@ -3,75 +3,71 @@
 //
 //
 #include "AssignUserTaskCmd.h"
-// MiscCommon
-#include "INet.h"
 
 using namespace std;
 using namespace dds;
 using namespace dds::protocol_api;
-namespace inet = MiscCommon::INet;
 
-void SAssignUserTaskCmd::normalizeToLocal() const
+SAssignUserTaskCmd::SAssignUserTaskCmd()
+    : m_sExeFile()
+    , m_sID()
+    , m_taskIndex(0)
+    , m_collectionIndex(0)
+    , m_taskPath()
+    , m_groupName()
+    , m_collectionName()
+    , m_taskName()
 {
-    m_taskIndex = inet::normalizeRead(m_taskIndex);
-    m_collectionIndex = inet::normalizeRead(m_collectionIndex);
 }
 
-void SAssignUserTaskCmd::normalizeToRemote() const
+size_t SAssignUserTaskCmd::size() const
 {
-    m_taskIndex = inet::normalizeWrite(m_taskIndex);
-    m_collectionIndex = inet::normalizeWrite(m_collectionIndex);
+    return dsize(m_sExeFile) + dsize(m_sID) + dsize(m_taskIndex) + dsize(m_collectionIndex) + dsize(m_taskPath) +
+           dsize(m_groupName) + dsize(m_collectionName) + dsize(m_taskName);
+}
+
+bool SAssignUserTaskCmd::operator==(const SAssignUserTaskCmd& val) const
+{
+    return (m_sExeFile == val.m_sExeFile && m_sID == val.m_sID && m_taskIndex == val.m_taskIndex &&
+            m_collectionIndex == val.m_collectionIndex && m_taskPath == val.m_taskPath &&
+            m_groupName == val.m_groupName && m_collectionName == val.m_collectionName && m_taskName == val.m_taskName);
 }
 
 void SAssignUserTaskCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    size_t idx(0);
-    inet::readData(&m_taskIndex, &_data, &idx);
-    inet::readData(&m_collectionIndex, &_data, &idx);
-
-    vector<string> v;
-    MiscCommon::BYTEVector_t::const_iterator iter = _data.begin();
-    advance(iter, idx);
-    MiscCommon::BYTEVector_t::const_iterator iter_end = _data.end();
-    for (; iter != iter_end;)
-    {
-        string tmp((string::value_type*)(&(*iter)));
-        v.push_back(tmp);
-        advance(iter, tmp.size() + 1);
-    }
-
-    // there are so far only 6 string fields in this msg container
-    if (v.size() != 6)
-        throw runtime_error("AssignUserTaskCmd: can't import data. Number of fields doesn't match.");
-
-    m_sExeFile.assign(v[0]);
-    m_sID.assign(v[1]);
-    m_taskPath.assign(v[2]);
-    m_groupName.assign(v[3]);
-    m_collectionName.assign(v[4]);
-    m_taskName.assign(v[5]);
+    SAttachmentDataProvider(_data)
+        .get(m_taskIndex)
+        .get(m_collectionIndex)
+        .get(m_sExeFile)
+        .get(m_sID)
+        .get(m_taskPath)
+        .get(m_groupName)
+        .get(m_collectionName)
+        .get(m_taskName);
 }
 
 void SAssignUserTaskCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    inet::pushData(m_taskIndex, _data);
-    inet::pushData(m_collectionIndex, _data);
+    SAttachmentDataProvider(_data)
+        .put(m_taskIndex)
+        .put(m_collectionIndex)
+        .put(m_sExeFile)
+        .put(m_sID)
+        .put(m_taskPath)
+        .put(m_groupName)
+        .put(m_collectionName)
+        .put(m_taskName);
+}
 
-    copy(m_sExeFile.begin(), m_sExeFile.end(), back_inserter(*_data));
-    _data->push_back('\0');
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SAssignUserTaskCmd& val)
+{
+    return _stream << "TaskId: " << val.m_sID << "; Exe: " << val.m_sExeFile << "; taskIndex:" << val.m_taskIndex
+                   << "; collectionIndex:" << val.m_collectionIndex << "; taskPath:" << val.m_taskPath
+                   << "; groupName:" << val.m_groupName << "; collectionName:" << val.m_collectionName
+                   << "; taskName: " << val.m_taskName;
+}
 
-    copy(m_sID.begin(), m_sID.end(), back_inserter(*_data));
-    _data->push_back('\0');
-
-    copy(m_taskPath.begin(), m_taskPath.end(), back_inserter(*_data));
-    _data->push_back('\0');
-
-    copy(m_groupName.begin(), m_groupName.end(), back_inserter(*_data));
-    _data->push_back('\0');
-
-    copy(m_collectionName.begin(), m_collectionName.end(), back_inserter(*_data));
-    _data->push_back('\0');
-
-    copy(m_taskName.begin(), m_taskName.end(), back_inserter(*_data));
-    _data->push_back('\0');
+bool dds::protocol_api::operator!=(const SAssignUserTaskCmd& lhs, const SAssignUserTaskCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/AssignUserTaskCmd.h
+++ b/dds-protocol-lib/src/AssignUserTaskCmd.h
@@ -14,47 +14,23 @@ namespace dds
     {
         struct SAssignUserTaskCmd : public SBasicCmd<SAssignUserTaskCmd>
         {
-            SAssignUserTaskCmd()
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                return (m_sExeFile.size() + 1 + m_sID.size() + 1 + sizeof(m_taskIndex) + sizeof(m_collectionIndex) +
-                        m_taskPath.size() + 1 + m_groupName.size() + 1 + m_collectionName.size() + 1 +
-                        m_taskName.size() + 1);
-            }
+            SAssignUserTaskCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SAssignUserTaskCmd& val) const
-            {
-                return (m_sExeFile == val.m_sExeFile && m_sID == val.m_sID && m_taskIndex == val.m_taskIndex &&
-                        m_collectionIndex == val.m_collectionIndex && m_taskPath == val.m_taskPath &&
-                        m_groupName == val.m_groupName && m_collectionName == val.m_collectionName &&
-                        m_taskName == val.m_taskName);
-            }
+            bool operator==(const SAssignUserTaskCmd& val) const;
 
             std::string m_sExeFile;
             std::string m_sID;
-            mutable uint32_t m_taskIndex;
-            mutable uint32_t m_collectionIndex;
+            uint32_t m_taskIndex;
+            uint32_t m_collectionIndex;
             std::string m_taskPath;
             std::string m_groupName;
             std::string m_collectionName;
             std::string m_taskName;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SAssignUserTaskCmd& val)
-        {
-            return _stream << "TaskId: " << val.m_sID << "; Exe: " << val.m_sExeFile
-                           << "; taskIndex:" << val.m_taskIndex << "; collectionIndex:" << val.m_collectionIndex
-                           << "; taskPath:" << val.m_taskPath << "; groupName:" << val.m_groupName
-                           << "; collectionName:" << val.m_collectionName << "; taskName: " << val.m_taskName;
-        }
-        inline bool operator!=(const SAssignUserTaskCmd& lhs, const SAssignUserTaskCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SAssignUserTaskCmd& val);
+        bool operator!=(const SAssignUserTaskCmd& lhs, const SAssignUserTaskCmd& rhs);
     }
 };
 

--- a/dds-protocol-lib/src/BasicCmd.h
+++ b/dds-protocol-lib/src/BasicCmd.h
@@ -7,26 +7,497 @@
 
 // MiscCommon
 #include "def.h"
+#include "INet.h"
+// STD
+#include <sstream>
+#include <string>
+// BOOST
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-register"
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#pragma clang diagnostic pop
+
+namespace inet = MiscCommon::INet;
 
 namespace dds
 {
     namespace protocol_api
     {
+        ///
+        /// All vectors (except uint8_t) have a maximum size of uint16_t i.e. 2^16.
+        /// All vector<uint8_t>'s have a maximum size of uint32_t i.e. 2^32.
+        /// All std::string's have a maximum size of uint16_t i.e. 2^16.
+        ///
+
+        ///
+        /// \function dsize
+        /// \brief Helper template function calculating size of the variable.
+        ///
+        template <typename T>
+        size_t dsize(const T& _value);
+
+        /// \brief Helper function calculating size of uint8_t
+        template <>
+        inline size_t dsize<uint8_t>(const uint8_t& _value)
+        {
+            return sizeof(uint8_t);
+        }
+
+        /// \brief Helper function calculating size of uint16_t
+        template <>
+        inline size_t dsize<uint16_t>(const uint16_t& _value)
+        {
+            return sizeof(uint16_t);
+        }
+
+        /// \brief Helper function calculating size of uint32_t
+        template <>
+        inline size_t dsize<uint32_t>(const uint32_t& _value)
+        {
+            return sizeof(uint32_t);
+        }
+
+        /// \brief Helper function calculating size of uint64_t
+        template <>
+        inline size_t dsize<uint64_t>(const uint64_t& _value)
+        {
+            return sizeof(uint64_t);
+        }
+
+        /// \brief Helper function calculating size of std::string
+        template <>
+        inline size_t dsize<std::string>(const std::string& _value)
+        {
+            return _value.size() + sizeof(uint16_t);
+        }
+
+        /// \brief Helper function calculating size of the vector of uint8_t
+        template <>
+        inline size_t dsize<std::vector<uint8_t>>(const std::vector<uint8_t>& _value)
+        {
+            return _value.size() * sizeof(uint8_t) + sizeof(uint32_t);
+        }
+
+        /// \brief Helper function calculating size of the vector of uint16_t
+        template <>
+        inline size_t dsize<std::vector<uint16_t>>(const std::vector<uint16_t>& _value)
+        {
+            return _value.size() * sizeof(uint16_t) + sizeof(uint16_t);
+        }
+
+        /// \brief Helper function calculating size of the vector of uint32_t
+        template <>
+        inline size_t dsize<std::vector<uint32_t>>(const std::vector<uint32_t>& _value)
+        {
+            return _value.size() * sizeof(uint32_t) + sizeof(uint16_t);
+        }
+
+        /// \brief Helper function calculating size of the vector of uint64_t
+        template <>
+        inline size_t dsize<std::vector<uint64_t>>(const std::vector<uint64_t>& _value)
+        {
+            return _value.size() * sizeof(uint64_t) + sizeof(uint16_t);
+        }
+
+        /// \brief Helper function calculating size of the vector of std::string
+        template <>
+        inline size_t dsize<std::vector<std::string>>(const std::vector<std::string>& _value)
+        {
+            size_t sum(sizeof(uint16_t));
+            for (const auto& v : _value)
+                sum += (v.size() + sizeof(uint16_t));
+            return sum;
+        }
+
+        /// \brief Helper function calculating size of the boost::uuids::uuid
+        template <>
+        inline size_t dsize<boost::uuids::uuid>(const boost::uuids::uuid& _value)
+        {
+            return boost::uuids::uuid::static_size();
+        }
+
+        ///
+        /// \function readData
+        /// \brief Helper template function reading data from byte array.
+        ///
+        template <typename T>
+        void readData(T* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos);
+
+        template <>
+        inline void readData<uint8_t>(uint8_t* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
+        {
+            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
+                throw std::invalid_argument("readDataFromContainer");
+
+            *_value = (*_data)[*_nPos];
+
+            ++(*_nPos);
+        }
+
+        template <>
+        inline void readData<uint16_t>(uint16_t* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
+        {
+            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
+                throw std::invalid_argument("readDataFromContainer");
+
+            *_value = (*_data)[*_nPos];
+            *_value += ((*_data)[++(*_nPos)] << 8);
+
+            *_value = inet::normalizeRead(*_value);
+
+            ++(*_nPos);
+        }
+
+        template <>
+        inline void readData<uint32_t>(uint32_t* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
+        {
+            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
+                throw std::invalid_argument("readDataFromContainer");
+
+            *_value = (*_data)[*_nPos];
+            *_value += ((*_data)[++(*_nPos)] << 8);
+            *_value += ((*_data)[++(*_nPos)] << 16);
+            *_value += ((*_data)[++(*_nPos)] << 24);
+
+            *_value = inet::normalizeRead(*_value);
+
+            ++(*_nPos);
+        }
+
+        template <>
+        inline void readData<uint64_t>(uint64_t* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
+        {
+            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
+                throw std::invalid_argument("readDataFromContainer");
+
+            *_value = (*_data)[*_nPos];
+            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 8);
+            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 16);
+            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 24);
+            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 32);
+            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 40);
+            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 48);
+            *_value += ((uint64_t)(*_data)[++(*_nPos)] << 56);
+
+            *_value = inet::normalizeRead(*_value);
+
+            ++(*_nPos);
+        }
+
+        template <>
+        inline void readData<std::string>(std::string* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
+        {
+            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
+                throw std::invalid_argument("readDataFromContainer");
+
+            if (_value->size() > std::numeric_limits<uint16_t>::max())
+                throw std::invalid_argument("String size can't exceed 2^16 symbols. String size: " +
+                                            std::to_string(_value->size()));
+
+            // Read number of elements in the string
+            uint16_t n = 0;
+            readData(&n, _data, _nPos);
+
+            MiscCommon::BYTEVector_t::const_iterator iter = _data->begin();
+            std::advance(iter, *_nPos);
+            MiscCommon::BYTEVector_t::const_iterator iter_end = _data->begin();
+            std::advance(iter_end, (*_nPos + n));
+            std::copy(iter, iter_end, back_inserter(*_value));
+
+            *_nPos += n;
+        }
+
+        template <>
+        inline void readData<boost::uuids::uuid>(boost::uuids::uuid* _value,
+                                                 const MiscCommon::BYTEVector_t* _data,
+                                                 size_t* _nPos)
+        {
+            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
+                throw std::invalid_argument("readDataFromContainer");
+
+            MiscCommon::BYTEVector_t::const_iterator iter = _data->begin();
+            std::advance(iter, *_nPos);
+            MiscCommon::BYTEVector_t::const_iterator iter_end = _data->begin();
+            std::advance(iter_end, (*_nPos + boost::uuids::uuid::static_size()));
+            copy(iter, iter_end, _value->begin());
+            (*_nPos) += boost::uuids::uuid::static_size();
+        }
+
+        template <typename T>
+        inline void readDataVector(std::vector<T>* _value, const MiscCommon::BYTEVector_t* _data, size_t* _nPos)
+        {
+            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
+                throw std::invalid_argument("readDataFromContainer");
+
+            if (_value->size() > std::numeric_limits<uint16_t>::max())
+                throw std::invalid_argument("Vector size can't exceed 2^16 symbols. Vector size: " +
+                                            std::to_string(_value->size()));
+
+            // Read number of elements in the vector
+            uint16_t n = 0;
+            readData(&n, _data, _nPos);
+
+            _value->reserve(n);
+            for (size_t i = 0; i < n; ++i)
+            {
+                T v;
+                readData(&v, _data, _nPos);
+                _value->push_back(v);
+            }
+        }
+
+        template <>
+        inline void readData<std::vector<uint8_t>>(std::vector<uint8_t>* _value,
+                                                   const MiscCommon::BYTEVector_t* _data,
+                                                   size_t* _nPos)
+        {
+            if (_data == nullptr || _nPos == nullptr || _value == nullptr)
+                throw std::invalid_argument("readDataFromContainer");
+
+            if (_value->size() > std::numeric_limits<uint32_t>::max())
+                throw std::invalid_argument("Vector<uint8_t> size can't exceed 2^32 symbols. Vector size: " +
+                                            std::to_string(_value->size()));
+
+            uint32_t n = 0;
+            readData(&n, _data, _nPos);
+
+            MiscCommon::BYTEVector_t::const_iterator iter = _data->begin();
+            std::advance(iter, *_nPos);
+            MiscCommon::BYTEVector_t::const_iterator iter_end = _data->begin();
+            std::advance(iter_end, (*_nPos + n));
+            std::copy(iter, iter_end, back_inserter(*_value));
+
+            *_nPos += n;
+        }
+
+        template <>
+        inline void readData<std::vector<uint16_t>>(std::vector<uint16_t>* _value,
+                                                    const MiscCommon::BYTEVector_t* _data,
+                                                    size_t* _nPos)
+        {
+            readDataVector<uint16_t>(_value, _data, _nPos);
+        }
+
+        template <>
+        inline void readData<std::vector<uint32_t>>(std::vector<uint32_t>* _value,
+                                                    const MiscCommon::BYTEVector_t* _data,
+                                                    size_t* _nPos)
+        {
+            readDataVector<uint32_t>(_value, _data, _nPos);
+        }
+
+        template <>
+        inline void readData<std::vector<uint64_t>>(std::vector<uint64_t>* _value,
+                                                    const MiscCommon::BYTEVector_t* _data,
+                                                    size_t* _nPos)
+        {
+            readDataVector<uint64_t>(_value, _data, _nPos);
+        }
+
+        template <>
+        inline void readData<std::vector<std::string>>(std::vector<std::string>* _value,
+                                                       const MiscCommon::BYTEVector_t* _data,
+                                                       size_t* _nPos)
+        {
+            readDataVector<std::string>(_value, _data, _nPos);
+        }
+
+        ///
+        /// \function pushData
+        /// \brief Helper template function pushing data to byte array.
+        ///
+        template <typename T>
+        void pushData(const T& _value, MiscCommon::BYTEVector_t* _data);
+
+        template <>
+        inline void pushData<uint8_t>(const uint8_t& _value, MiscCommon::BYTEVector_t* _data)
+        {
+            if (_data == nullptr)
+                throw std::invalid_argument("pushDataFromContainer");
+
+            _data->push_back(_value);
+        }
+
+        template <>
+        inline void pushData<uint16_t>(const uint16_t& _value, MiscCommon::BYTEVector_t* _data)
+        {
+            if (_data == nullptr)
+                throw std::invalid_argument("pushDataFromContainer");
+
+            uint16_t value = inet::normalizeWrite(_value);
+            _data->push_back(value & 0xFF);
+            _data->push_back(value >> 8);
+        }
+
+        template <>
+        inline void pushData<uint32_t>(const uint32_t& _value, MiscCommon::BYTEVector_t* _data)
+        {
+            if (_data == nullptr)
+                throw std::invalid_argument("pushDataFromContainer");
+
+            uint32_t value = inet::normalizeWrite(_value);
+            _data->push_back(value & 0xFF);
+            _data->push_back((value >> 8) & 0xFF);
+            _data->push_back((value >> 16) & 0xFF);
+            _data->push_back((value >> 24) & 0xFF);
+        }
+
+        template <>
+        inline void pushData<uint64_t>(const uint64_t& _value, MiscCommon::BYTEVector_t* _data)
+        {
+            if (_data == nullptr)
+                throw std::invalid_argument("pushDataFromContainer");
+
+            uint64_t value = inet::normalizeWrite(_value);
+            _data->push_back(value & 0xFF);
+            _data->push_back((value >> 8) & 0xFF);
+            _data->push_back((value >> 16) & 0xFF);
+            _data->push_back((value >> 24) & 0xFF);
+            _data->push_back((value >> 32) & 0xFF);
+            _data->push_back((value >> 40) & 0xFF);
+            _data->push_back((value >> 48) & 0xFF);
+            _data->push_back((value >> 56) & 0xFF);
+        }
+
+        template <>
+        inline void pushData<std::string>(const std::string& _value, MiscCommon::BYTEVector_t* _data)
+        {
+            if (_data == nullptr)
+                throw std::invalid_argument("pushDataFromContainer");
+
+            if (_value.size() > std::numeric_limits<uint16_t>::max())
+                throw std::invalid_argument("String size can't exceed 2^16 symbols. String size: " +
+                                            std::to_string(_value.size()));
+
+            uint16_t n = _value.size();
+            pushData(n, _data);
+            copy(_value.begin(), _value.end(), back_inserter(*_data));
+        }
+
+        template <>
+        inline void pushData<boost::uuids::uuid>(const boost::uuids::uuid& _value, MiscCommon::BYTEVector_t* _data)
+        {
+            if (_data == nullptr)
+                throw std::invalid_argument("pushDataFromContainer");
+
+            copy(_value.begin(), _value.end(), back_inserter(*_data));
+        }
+
+        template <typename T>
+        inline void pushDataVector(const std::vector<T>& _value, MiscCommon::BYTEVector_t* _data)
+        {
+            if (_data == nullptr)
+                throw std::invalid_argument("pushDataFromContainer");
+
+            if (_value.size() > std::numeric_limits<uint16_t>::max())
+                throw std::invalid_argument("Vector size can't exceed 2^16 symbols. Vector size: " +
+                                            std::to_string(_value.size()));
+
+            // Read number of elements in the vector
+            uint16_t n = _value.size();
+            pushData(n, _data);
+
+            for (const T& v : _value)
+            {
+                pushData(v, _data);
+            }
+        }
+
+        template <>
+        inline void pushData<std::vector<uint8_t>>(const std::vector<uint8_t>& _value, MiscCommon::BYTEVector_t* _data)
+        {
+            if (_data == nullptr)
+                throw std::invalid_argument("pushDataFromContainer");
+
+            if (_value.size() > std::numeric_limits<uint32_t>::max())
+                throw std::invalid_argument("Vector<uint32_t> size can't exceed 2^32 symbols. Vector size: " +
+                                            std::to_string(_value.size()));
+
+            uint32_t n = _value.size();
+            pushData(n, _data);
+            copy(_value.begin(), _value.end(), back_inserter(*_data));
+        }
+
+        template <>
+        inline void pushData<std::vector<uint16_t>>(const std::vector<uint16_t>& _value,
+                                                    MiscCommon::BYTEVector_t* _data)
+        {
+            pushDataVector<uint16_t>(_value, _data);
+        }
+
+        template <>
+        inline void pushData<std::vector<uint32_t>>(const std::vector<uint32_t>& _value,
+                                                    MiscCommon::BYTEVector_t* _data)
+        {
+            pushDataVector<uint32_t>(_value, _data);
+        }
+
+        template <>
+        inline void pushData<std::vector<uint64_t>>(const std::vector<uint64_t>& _value,
+                                                    MiscCommon::BYTEVector_t* _data)
+        {
+            pushDataVector<uint64_t>(_value, _data);
+        }
+
+        template <>
+        inline void pushData<std::vector<std::string>>(const std::vector<std::string>& _value,
+                                                       MiscCommon::BYTEVector_t* _data)
+        {
+            pushDataVector<std::string>(_value, _data);
+        }
+
+        struct SAttachmentDataProvider
+        {
+            SAttachmentDataProvider(MiscCommon::BYTEVector_t* _data)
+                : m_data(_data)
+                , m_pos(0)
+            {
+            }
+
+            SAttachmentDataProvider(const MiscCommon::BYTEVector_t& _data)
+                : m_data(const_cast<MiscCommon::BYTEVector_t*>(&_data))
+                , m_pos(0)
+            {
+            }
+
+            template <typename T>
+            SAttachmentDataProvider& get(T& _value)
+            {
+                readData(&_value, m_data, &m_pos);
+                return *this;
+            }
+
+            template <typename T>
+            const SAttachmentDataProvider& put(const T& _value) const
+            {
+                pushData(_value, m_data);
+                return *this;
+            }
+
+          private:
+            MiscCommon::BYTEVector_t* m_data;
+            size_t m_pos;
+        };
+
         template <class _Owner>
         struct SBasicCmd
         {
             void convertFromData(const MiscCommon::BYTEVector_t& _data)
             {
                 _Owner* p = reinterpret_cast<_Owner*>(this);
+                if (_data.size() < p->size())
+                {
+                    std::stringstream ss;
+                    ss << "Protocol message data is too short, expected " << p->size() << " received " << _data.size();
+                    throw std::runtime_error(ss.str());
+                }
                 p->_convertFromData(_data);
-                p->normalizeToLocal();
             }
             void convertToData(MiscCommon::BYTEVector_t* _data) const
             {
                 const _Owner* p = reinterpret_cast<const _Owner*>(this);
-                p->normalizeToRemote();
                 p->_convertToData(_data);
-                p->normalizeToLocal();
             }
         };
     }

--- a/dds-protocol-lib/src/BinaryAttachmentCmd.h
+++ b/dds-protocol-lib/src/BinaryAttachmentCmd.h
@@ -20,55 +20,20 @@ namespace dds
     {
         struct SBinaryAttachmentCmd : public SBasicCmd<SBinaryAttachmentCmd>
         {
-            SBinaryAttachmentCmd()
-                : m_fileId()
-                , m_offset(0)
-                , m_size(0)
-                , m_crc32(0)
-                , m_data()
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t size(boost::uuids::uuid::static_size());
-                size += m_data.size();
-                size += sizeof(m_offset);
-                size += sizeof(m_size);
-                size += sizeof(m_crc32);
-                return size;
-            }
+            SBinaryAttachmentCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SBinaryAttachmentCmd& _val) const
-            {
-                unsigned int i = 0;
-                for (auto c : _val.m_data)
-                {
-                    if (m_data[i++] != c)
-                        return false;
-                }
-                return (m_fileId == _val.m_fileId && m_offset == _val.m_offset && m_size == _val.m_size &&
-                        m_crc32 == _val.m_crc32);
-            }
+            bool operator==(const SBinaryAttachmentCmd& _val) const;
 
             boost::uuids::uuid m_fileId;     ///> Unique ID of the file
-            mutable uint32_t m_offset;       ///> Offset for this piece of binary data
-            mutable uint32_t m_size;         ///> Size of this piece of binary data
-            mutable uint32_t m_crc32;        ///> CRC checksum of this piece of binary data
+            uint32_t m_offset;               ///> Offset for this piece of binary data
+            uint32_t m_size;                 ///> Size of this piece of binary data
+            uint32_t m_crc32;                ///> CRC checksum of this piece of binary data
             MiscCommon::BYTEVector_t m_data; ///> Piece of binary data
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SBinaryAttachmentCmd& _val)
-        {
-            _stream << "fileId=" << _val.m_fileId << " offset=" << _val.m_offset << " size=" << _val.m_size
-                    << " crc32=" << _val.m_crc32;
-            for (const auto& c : _val.m_data)
-            {
-                _stream << c;
-            }
-            return _stream;
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SBinaryAttachmentCmd& _val);
+        bool operator!=(const SBinaryAttachmentCmd& lhs, const SBinaryAttachmentCmd& rhs);
     }
 };
 

--- a/dds-protocol-lib/src/BinaryAttachmentReceivedCmd.h
+++ b/dds-protocol-lib/src/BinaryAttachmentReceivedCmd.h
@@ -14,47 +14,20 @@ namespace dds
     {
         struct SBinaryAttachmentReceivedCmd : public SBasicCmd<SBinaryAttachmentReceivedCmd>
         {
-            SBinaryAttachmentReceivedCmd()
-                : m_receivedFilePath()
-                , m_requestedFileName()
-                , m_srcCommand(0)
-                , m_receivedFileSize(0)
-                , m_downloadTime(0)
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t size(m_receivedFilePath.size() + 1);
-                size += (m_requestedFileName.size() + 1);
-                size += sizeof(m_srcCommand);
-                size += sizeof(m_receivedFileSize);
-                size += sizeof(m_downloadTime);
-                return size;
-            }
+            SBinaryAttachmentReceivedCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SBinaryAttachmentReceivedCmd& _val) const
-            {
-                return (m_receivedFilePath == _val.m_receivedFilePath &&
-                        m_requestedFileName == _val.m_requestedFileName && m_srcCommand == _val.m_srcCommand &&
-                        m_receivedFileSize == _val.m_receivedFileSize && m_downloadTime == _val.m_downloadTime);
-            }
+            bool operator==(const SBinaryAttachmentReceivedCmd& _val) const;
 
-            std::string m_receivedFilePath;      ///> Path to the received file
-            std::string m_requestedFileName;     ///> Requested name of the file
-            mutable uint16_t m_srcCommand;       ///> Source command which initiated file transport
-            mutable uint32_t m_receivedFileSize; ///> Number of recieved bytes
-            mutable uint32_t m_downloadTime;     ///> Time spent to download file [microseconds]
+            std::string m_receivedFilePath;  ///> Path to the received file
+            std::string m_requestedFileName; ///> Requested name of the file
+            uint16_t m_srcCommand;           ///> Source command which initiated file transport
+            uint32_t m_receivedFileSize;     ///> Number of recieved bytes
+            uint32_t m_downloadTime;         ///> Time spent to download file [microseconds]
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SBinaryAttachmentReceivedCmd& _val)
-        {
-            _stream << "receivedFilePath=" << _val.m_receivedFilePath
-                    << " requestedFileName=" << _val.m_requestedFileName
-                    << " receivedFileSize=" << _val.m_receivedFileSize << " downloadTime=" << _val.m_downloadTime;
-            return _stream;
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SBinaryAttachmentReceivedCmd& _val);
+        bool operator!=(const SBinaryAttachmentReceivedCmd& lhs, const SBinaryAttachmentReceivedCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/BinaryAttachmentStartCmd.cpp
+++ b/dds-protocol-lib/src/BinaryAttachmentStartCmd.cpp
@@ -11,56 +11,43 @@ using namespace dds;
 using namespace dds::protocol_api;
 namespace inet = MiscCommon::INet;
 
-void SBinaryAttachmentStartCmd::normalizeToLocal() const
+SBinaryAttachmentStartCmd::SBinaryAttachmentStartCmd()
+    : m_fileId()
+    , m_fileName()
+    , m_fileSize(0)
+    , m_fileCrc32(0)
+    , m_srcCommand(0)
 {
-    m_fileCrc32 = inet::normalizeRead(m_fileCrc32);
-    m_fileSize = inet::normalizeRead(m_fileSize);
-    m_srcCommand = inet::normalizeRead(m_srcCommand);
+}
+size_t SBinaryAttachmentStartCmd::size() const
+{
+    return dsize(m_fileId) + dsize(m_fileName) + dsize(m_fileSize) + dsize(m_fileCrc32) + dsize(m_srcCommand);
 }
 
-void SBinaryAttachmentStartCmd::normalizeToRemote() const
+bool SBinaryAttachmentStartCmd::operator==(const SBinaryAttachmentStartCmd& _val) const
 {
-    m_fileCrc32 = inet::normalizeWrite(m_fileCrc32);
-    m_fileSize = inet::normalizeWrite(m_fileSize);
-    m_srcCommand = inet::normalizeWrite(m_srcCommand);
+    return (m_fileId == _val.m_fileId && m_fileCrc32 == _val.m_fileCrc32 && m_fileName == _val.m_fileName &&
+            m_fileSize == _val.m_fileSize && m_srcCommand == _val.m_srcCommand);
 }
 
 void SBinaryAttachmentStartCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    size_t idx(0);
-    MiscCommon::BYTEVector_t::const_iterator iter = _data.begin();
-    MiscCommon::BYTEVector_t::const_iterator iter_end = _data.end();
-
-    for (; iter != iter_end; ++iter, ++idx)
-    {
-        char c(*iter);
-        if ('\0' == c)
-        {
-            ++iter;
-            ++idx;
-            break;
-        }
-        m_fileName.push_back(c);
-    }
-
-    auto iter_id_begin = _data.begin() + idx;
-    auto iter_id_end = iter_id_begin + m_fileId.size();
-    copy(iter_id_begin, iter_id_end, m_fileId.begin());
-    idx += m_fileId.size();
-
-    inet::readData(&m_fileSize, &_data, &idx);
-    inet::readData(&m_fileCrc32, &_data, &idx);
-    inet::readData(&m_srcCommand, &_data, &idx);
+    SAttachmentDataProvider(_data).get(m_fileId).get(m_fileName).get(m_fileSize).get(m_fileCrc32).get(m_srcCommand);
 }
 
 void SBinaryAttachmentStartCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    copy(m_fileName.begin(), m_fileName.end(), back_inserter(*_data));
-    _data->push_back('\0');
+    SAttachmentDataProvider(_data).put(m_fileId).put(m_fileName).put(m_fileSize).put(m_fileCrc32).put(m_srcCommand);
+}
 
-    copy(m_fileId.begin(), m_fileId.end(), back_inserter(*_data));
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SBinaryAttachmentStartCmd& _val)
+{
+    _stream << "fileId=" << _val.m_fileId << " fileName=" << _val.m_fileName << " fileSize=" << _val.m_fileSize
+            << " fileCrc32=" << _val.m_fileCrc32;
+    return _stream;
+}
 
-    inet::pushData(m_fileSize, _data);
-    inet::pushData(m_fileCrc32, _data);
-    inet::pushData(m_srcCommand, _data);
+bool dds::protocol_api::operator!=(const SBinaryAttachmentStartCmd& lhs, const SBinaryAttachmentStartCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/BinaryAttachmentStartCmd.h
+++ b/dds-protocol-lib/src/BinaryAttachmentStartCmd.h
@@ -20,45 +20,20 @@ namespace dds
     {
         struct SBinaryAttachmentStartCmd : public SBasicCmd<SBinaryAttachmentStartCmd>
         {
-            SBinaryAttachmentStartCmd()
-                : m_fileId()
-                , m_fileName()
-                , m_fileSize(0)
-                , m_fileCrc32(0)
-                , m_srcCommand(0)
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t size(boost::uuids::uuid::static_size());
-                size += (m_fileName.size() + 1);
-                size += sizeof(m_fileSize);
-                size += sizeof(m_fileCrc32);
-                size += sizeof(m_srcCommand);
-                return size;
-            }
+            SBinaryAttachmentStartCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SBinaryAttachmentStartCmd& _val) const
-            {
-                return (m_fileId == _val.m_fileId && m_fileCrc32 == _val.m_fileCrc32 && m_fileName == _val.m_fileName &&
-                        m_fileSize == _val.m_fileSize && m_srcCommand == _val.m_srcCommand);
-            }
+            bool operator==(const SBinaryAttachmentStartCmd& _val) const;
 
-            boost::uuids::uuid m_fileId;   ///> Unique ID of the file
-            std::string m_fileName;        ///> Name of the file
-            mutable uint32_t m_fileSize;   ///> File size in bytes
-            mutable uint32_t m_fileCrc32;  ///> File checksum
-            mutable uint16_t m_srcCommand; ///> Source command which initiated file transport
+            boost::uuids::uuid m_fileId; ///> Unique ID of the file
+            std::string m_fileName;      ///> Name of the file
+            uint32_t m_fileSize;         ///> File size in bytes
+            uint32_t m_fileCrc32;        ///> File checksum
+            uint16_t m_srcCommand;       ///> Source command which initiated file transport
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SBinaryAttachmentStartCmd& _val)
-        {
-            _stream << "fileId=" << _val.m_fileId << " fileName=" << _val.m_fileName << " fileSize=" << _val.m_fileSize
-                    << " fileCrc32=" << _val.m_fileCrc32;
-            return _stream;
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SBinaryAttachmentStartCmd& _val);
+        bool operator!=(const SBinaryAttachmentStartCmd& lhs, const SBinaryAttachmentStartCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/CustomCmdCmd.cpp
+++ b/dds-protocol-lib/src/CustomCmdCmd.cpp
@@ -12,53 +12,39 @@ using namespace dds;
 using namespace dds::protocol_api;
 namespace inet = MiscCommon::INet;
 
-void SCustomCmdCmd::normalizeToLocal() const
+SCustomCmdCmd::SCustomCmdCmd()
+    : m_senderId(0)
+    , m_sCmd()
+    , m_sCondition()
 {
-    m_senderId = inet::normalizeRead(m_senderId);
 }
 
-void SCustomCmdCmd::normalizeToRemote() const
+size_t SCustomCmdCmd::size() const
 {
-    m_senderId = inet::normalizeWrite(m_senderId);
+    return dsize(m_senderId) + dsize(m_sCmd) + dsize(m_sCondition);
+}
+
+bool SCustomCmdCmd::operator==(const SCustomCmdCmd& val) const
+{
+    return (m_senderId == val.m_senderId && m_sCmd == val.m_sCmd && m_sCondition == val.m_sCondition);
 }
 
 void SCustomCmdCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "CustomCmd: Protocol message data is too short, expected " << size() << " received " << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    size_t idx(0);
-    inet::readData(&m_senderId, &_data, &idx);
-
-    vector<string> v;
-    MiscCommon::BYTEVector_t::const_iterator iter = _data.begin();
-    advance(iter, idx);
-    MiscCommon::BYTEVector_t::const_iterator iter_end = _data.end();
-    for (; iter != iter_end;)
-    {
-        string tmp((string::value_type*)(&(*iter)));
-        v.push_back(tmp);
-        advance(iter, tmp.size() + 1);
-    }
-
-    // there are so far only 2 string fields in this msg container
-    if (v.size() != 2)
-        throw runtime_error("CustomCmd: can't import data. Number of fields doesn't match.");
-
-    m_sCmd.assign(v[0]);
-    m_sCondition.assign(v[1]);
+    SAttachmentDataProvider(_data).get(m_senderId).get(m_sCmd).get(m_sCondition);
 }
 
 void SCustomCmdCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    inet::pushData(m_senderId, _data);
+    SAttachmentDataProvider(_data).put(m_senderId).put(m_sCmd).put(m_sCondition);
+}
 
-    copy(m_sCmd.begin(), m_sCmd.end(), back_inserter(*_data));
-    _data->push_back('\0');
-    copy(m_sCondition.begin(), m_sCondition.end(), back_inserter(*_data));
-    _data->push_back('\0');
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SCustomCmdCmd& val)
+{
+    return _stream << "senderId:" << val.m_senderId << "cmd: " << val.m_sCmd << " condition: " << val.m_sCondition;
+}
+
+bool dds::protocol_api::operator!=(const SCustomCmdCmd& lhs, const SCustomCmdCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/CustomCmdCmd.h
+++ b/dds-protocol-lib/src/CustomCmdCmd.h
@@ -13,39 +13,18 @@ namespace dds
     {
         struct SCustomCmdCmd : public SBasicCmd<SCustomCmdCmd>
         {
-            SCustomCmdCmd()
-                : m_senderId(0)
-                , m_sCmd()
-                , m_sCondition()
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t s = sizeof(m_senderId) + (m_sCmd.size() + 1) + (m_sCondition.size() + 1);
-                return s;
-            }
+            SCustomCmdCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SCustomCmdCmd& val) const
-            {
-                return (m_senderId == val.m_senderId && m_sCmd == val.m_sCmd && m_sCondition == val.m_sCondition);
-            }
+            bool operator==(const SCustomCmdCmd& val) const;
 
-            mutable uint64_t m_senderId;
+            uint64_t m_senderId;
             std::string m_sCmd;
             std::string m_sCondition;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SCustomCmdCmd& val)
-        {
-            return _stream << "senderId:" << val.m_senderId << "cmd: " << val.m_sCmd
-                           << " condition: " << val.m_sCondition;
-        }
-        inline bool operator!=(const SCustomCmdCmd& lhs, const SCustomCmdCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SCustomCmdCmd& val);
+        bool operator!=(const SCustomCmdCmd& lhs, const SCustomCmdCmd& rhs);
     }
 }
 #endif

--- a/dds-protocol-lib/src/DeleteKeyCmd.cpp
+++ b/dds-protocol-lib/src/DeleteKeyCmd.cpp
@@ -4,47 +4,44 @@
 //
 #include "DeleteKeyCmd.h"
 #include <stdexcept>
+#include "INet.h"
 
 using namespace std;
 using namespace dds;
 using namespace dds::protocol_api;
+namespace inet = MiscCommon::INet;
 
-void SDeleteKeyCmd::normalizeToLocal() const
+SDeleteKeyCmd::SDeleteKeyCmd()
+    : m_sKey()
 {
 }
 
-void SDeleteKeyCmd::normalizeToRemote() const
+size_t SDeleteKeyCmd::size() const
 {
+    return dsize(m_sKey);
+}
+
+bool SDeleteKeyCmd::operator==(const SDeleteKeyCmd& val) const
+{
+    return (m_sKey == val.m_sKey);
 }
 
 void SDeleteKeyCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "DeleteKeyCmd: Protocol message data is too short, expected " << size() << " received " << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    vector<string> v;
-    MiscCommon::BYTEVector_t::const_iterator iter = _data.begin();
-    MiscCommon::BYTEVector_t::const_iterator iter_end = _data.end();
-    for (; iter != iter_end;)
-    {
-        string tmp((string::value_type*)(&(*iter)));
-        v.push_back(tmp);
-        advance(iter, tmp.size() + 1);
-    }
-
-    // there are so far only 2 string fields in this msg container
-    if (v.size() != 1)
-        throw runtime_error("DeleteKeyCmd: can't import data. Number of fields doesn't match.");
-
-    m_sKey.assign(v[0]);
+    SAttachmentDataProvider(_data).get(m_sKey);
 }
 
 void SDeleteKeyCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    copy(m_sKey.begin(), m_sKey.end(), back_inserter(*_data));
-    _data->push_back('\0');
+    SAttachmentDataProvider(_data).put(m_sKey);
+}
+
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SDeleteKeyCmd& val)
+{
+    return _stream << "key: " << val.m_sKey;
+}
+
+bool dds::protocol_api::operator!=(const SDeleteKeyCmd& lhs, const SDeleteKeyCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/DeleteKeyCmd.h
+++ b/dds-protocol-lib/src/DeleteKeyCmd.h
@@ -15,33 +15,16 @@ namespace dds
     {
         struct SDeleteKeyCmd : public SBasicCmd<SDeleteKeyCmd>
         {
-            SDeleteKeyCmd()
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t s = (m_sKey.size() + 1);
-                return s;
-            }
+            SDeleteKeyCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SDeleteKeyCmd& val) const
-            {
-                return (m_sKey == val.m_sKey);
-            }
+            bool operator==(const SDeleteKeyCmd& val) const;
 
             std::string m_sKey;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SDeleteKeyCmd& val)
-        {
-            return _stream << "key: " << val.m_sKey;
-        }
-        inline bool operator!=(const SDeleteKeyCmd& lhs, const SDeleteKeyCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SDeleteKeyCmd& val);
+        bool operator!=(const SDeleteKeyCmd& lhs, const SDeleteKeyCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/GetPropValuesCmd.cpp
+++ b/dds-protocol-lib/src/GetPropValuesCmd.cpp
@@ -5,48 +5,43 @@
 
 #include "GetPropValuesCmd.h"
 #include <stdexcept>
+#include "INet.h"
 
 using namespace std;
 using namespace dds;
 using namespace dds::protocol_api;
+namespace inet = MiscCommon::INet;
 
-void SGetPropValuesCmd::normalizeToLocal() const
+SGetPropValuesCmd::SGetPropValuesCmd()
+    : m_sPropertyID()
 {
 }
-
-void SGetPropValuesCmd::normalizeToRemote() const
+size_t SGetPropValuesCmd::size() const
 {
+    return dsize(m_sPropertyID);
+}
+
+bool SGetPropValuesCmd::operator==(const SGetPropValuesCmd& val) const
+{
+    return (m_sPropertyID == val.m_sPropertyID);
 }
 
 void SGetPropValuesCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "GetPropValuesCmd: Protocol message data is too short, expected " << size() << " received "
-           << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    vector<string> v;
-    MiscCommon::BYTEVector_t::const_iterator iter = _data.begin();
-    MiscCommon::BYTEVector_t::const_iterator iter_end = _data.end();
-    for (; iter != iter_end;)
-    {
-        string tmp((string::value_type*)(&(*iter)));
-        v.push_back(tmp);
-        advance(iter, tmp.size() + 1);
-    }
-
-    // there are so far only 1 string field1 in this msg container
-    if (v.size() != 1)
-        throw runtime_error("GetPropValuesCmd: can't import data. Number of fields doesn't match.");
-
-    m_sPropertyID.assign(v[0]);
+    SAttachmentDataProvider(_data).get(m_sPropertyID);
 }
 
 void SGetPropValuesCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    copy(m_sPropertyID.begin(), m_sPropertyID.end(), back_inserter(*_data));
-    _data->push_back('\0');
+    SAttachmentDataProvider(_data).put(m_sPropertyID);
+}
+
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SGetPropValuesCmd& val)
+{
+    return _stream << "propertyID: " << val.m_sPropertyID;
+}
+
+bool dds::protocol_api::operator!=(const SGetPropValuesCmd& lhs, const SGetPropValuesCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/GetPropValuesCmd.h
+++ b/dds-protocol-lib/src/GetPropValuesCmd.h
@@ -15,33 +15,16 @@ namespace dds
     {
         struct SGetPropValuesCmd : public SBasicCmd<SGetPropValuesCmd>
         {
-            SGetPropValuesCmd()
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t s = (m_sPropertyID.size() + 1);
-                return s;
-            }
+            SGetPropValuesCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SGetPropValuesCmd& val) const
-            {
-                return (m_sPropertyID == val.m_sPropertyID);
-            }
+            bool operator==(const SGetPropValuesCmd& val) const;
 
             std::string m_sPropertyID;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SGetPropValuesCmd& val)
-        {
-            return _stream << "propertyID: " << val.m_sPropertyID;
-        }
-        inline bool operator!=(const SGetPropValuesCmd& lhs, const SGetPropValuesCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SGetPropValuesCmd& val);
+        bool operator!=(const SGetPropValuesCmd& lhs, const SGetPropValuesCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/HostInfoCmd.h
+++ b/dds-protocol-lib/src/HostInfoCmd.h
@@ -14,61 +14,24 @@ namespace dds
     {
         struct SHostInfoCmd : public SBasicCmd<SHostInfoCmd>
         {
-            SHostInfoCmd()
-                : m_agentPort(0)
-                , m_agentPid(0)
-                , m_submitTime(0)
-                , m_username()
-                , m_host()
-                , m_version()
-                , m_DDSPath()
-                , m_workerId()
-            {
-            }
-            size_t size() const
-            {
-                size_t size(m_username.size() + 1);
-                size += m_host.size() + 1;
-                size += sizeof(m_agentPort);
-                size += sizeof(m_agentPid);
-                size += sizeof(m_submitTime);
-                size += m_version.size() + 1;
-                size += m_DDSPath.size() + 1;
-                size += m_workerId.size() + 1;
-                return size;
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
+            SHostInfoCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SHostInfoCmd& val) const
-            {
-                return (m_username == val.m_username && m_host == val.m_host && m_version == val.m_version &&
-                        m_DDSPath == val.m_DDSPath && m_agentPort == val.m_agentPort && m_agentPid == val.m_agentPid &&
-                        m_submitTime == val.m_submitTime && m_workerId == val.m_workerId);
-            }
+            bool operator==(const SHostInfoCmd& val) const;
 
-            mutable uint16_t m_agentPort;
-            mutable uint32_t m_agentPid;
+            uint16_t m_agentPort;
+            uint32_t m_agentPid;
             // milliseconds since 1970-01-01 00:00:00 UTC
-            mutable uint64_t m_submitTime;
+            uint64_t m_submitTime;
             std::string m_username;
             std::string m_host;
             std::string m_version;
             std::string m_DDSPath;
             std::string m_workerId;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SHostInfoCmd& val)
-        {
-            _stream << val.m_username << ":" << val.m_host << ": " << val.m_version << ":" << val.m_DDSPath
-                    << "; agent [" << val.m_agentPid << "] on port " << val.m_agentPort
-                    << "; startup time: " << val.m_submitTime << "; worker ID:" << val.m_workerId;
-            return _stream;
-        }
-        inline bool operator!=(const SHostInfoCmd& lhs, const SHostInfoCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SHostInfoCmd& val);
+        bool operator!=(const SHostInfoCmd& lhs, const SHostInfoCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/ProgressCmd.cpp
+++ b/dds-protocol-lib/src/ProgressCmd.cpp
@@ -15,42 +15,50 @@ using namespace dds;
 using namespace dds::protocol_api;
 namespace inet = MiscCommon::INet;
 
-void SProgressCmd::normalizeToLocal() const
+SProgressCmd::SProgressCmd()
+    : m_completed(0)
+    , m_total(0)
+    , m_errors(0)
+    , m_time(0)
 {
-    m_completed = inet::normalizeRead(m_completed);
-    m_total = inet::normalizeRead(m_total);
-    m_errors = inet::normalizeRead(m_errors);
-    m_time = inet::normalizeRead(m_time);
 }
 
-void SProgressCmd::normalizeToRemote() const
+SProgressCmd::SProgressCmd(uint32_t _completed, uint32_t _total, uint32_t _errors, uint32_t _time)
+    : m_completed(_completed)
+    , m_total(_total)
+    , m_errors(_errors)
+    , m_time(_time)
 {
-    m_completed = inet::normalizeWrite(m_completed);
-    m_total = inet::normalizeWrite(m_total);
-    m_errors = inet::normalizeWrite(m_errors);
-    m_time = inet::normalizeWrite(m_time);
+}
+
+size_t SProgressCmd::size() const
+{
+    return dsize(m_completed) + dsize(m_total) + dsize(m_errors) + dsize(m_time);
+}
+
+bool SProgressCmd::operator==(const SProgressCmd& val) const
+{
+    return (m_completed == val.m_completed && m_total == val.m_total && m_errors == val.m_errors &&
+            m_time == val.m_time);
 }
 
 void SProgressCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "SProgressCmd: Protocol message data is too short, expected " << size() << " received " << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    size_t idx(0);
-    inet::readData(&m_completed, &_data, &idx);
-    inet::readData(&m_total, &_data, &idx);
-    inet::readData(&m_errors, &_data, &idx);
-    inet::readData(&m_time, &_data, &idx);
+    SAttachmentDataProvider(_data).get(m_completed).get(m_total).get(m_errors).get(m_time);
 }
 
 void SProgressCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    inet::pushData(m_completed, _data);
-    inet::pushData(m_total, _data);
-    inet::pushData(m_errors, _data);
-    inet::pushData(m_time, _data);
+    SAttachmentDataProvider(_data).put(m_completed).put(m_total).put(m_errors).put(m_time);
+}
+
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SProgressCmd& val)
+{
+    return _stream << "source command: completed=" << val.m_completed << " total=" << val.m_total
+                   << " errors=" << val.m_errors << " time=" << val.m_time;
+}
+
+bool dds::protocol_api::operator!=(const SProgressCmd& lhs, const SProgressCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/ProgressCmd.h
+++ b/dds-protocol-lib/src/ProgressCmd.h
@@ -18,48 +18,20 @@ namespace dds
     {
         struct SProgressCmd : public SBasicCmd<SProgressCmd>
         {
-            SProgressCmd()
-                : m_completed(0)
-                , m_total(0)
-                , m_errors(0)
-                , m_time(0)
-            {
-            }
-            SProgressCmd(uint32_t _completed, uint32_t _total, uint32_t _errors, uint32_t _time = 0)
-                : m_completed(_completed)
-                , m_total(_total)
-                , m_errors(_errors)
-                , m_time(_time)
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                return sizeof(m_completed) + sizeof(m_total) + sizeof(m_errors) + sizeof(m_time);
-            }
+            SProgressCmd();
+            SProgressCmd(uint32_t _completed, uint32_t _total, uint32_t _errors, uint32_t _time = 0);
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SProgressCmd& val) const
-            {
-                return (m_completed == val.m_completed && m_total == val.m_total && m_errors == val.m_errors &&
-                        m_time == val.m_time);
-            }
+            bool operator==(const SProgressCmd& val) const;
 
-            mutable uint32_t m_completed;
-            mutable uint32_t m_total;
-            mutable uint32_t m_errors;
-            mutable uint32_t m_time;
+            uint32_t m_completed;
+            uint32_t m_total;
+            uint32_t m_errors;
+            uint32_t m_time;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SProgressCmd& val)
-        {
-            return _stream << "source command: completed=" << val.m_completed << " total=" << val.m_total
-                           << " errors=" << val.m_errors << " time=" << val.m_time;
-        }
-        inline bool operator!=(const SProgressCmd& lhs, const SProgressCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SProgressCmd& val);
+        bool operator!=(const SProgressCmd& lhs, const SProgressCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/SetTopologyCmd.h
+++ b/dds-protocol-lib/src/SetTopologyCmd.h
@@ -14,37 +14,19 @@ namespace dds
     {
         struct SSetTopologyCmd : public SBasicCmd<SSetTopologyCmd>
         {
-            SSetTopologyCmd()
-                : m_nDisiableValidation(0)
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                return (m_sTopologyFile.size() + 1) + sizeof(m_nDisiableValidation);
-            }
+            SSetTopologyCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SSetTopologyCmd& val) const
-            {
-                return (m_sTopologyFile == val.m_sTopologyFile && m_nDisiableValidation == val.m_nDisiableValidation);
-            }
+            bool operator==(const SSetTopologyCmd& val) const;
 
             // when 0 - valiadate, any other value - don't validate
-            mutable uint16_t m_nDisiableValidation;
+            uint16_t m_nDisiableValidation;
             // topology file
             std::string m_sTopologyFile;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SSetTopologyCmd& val)
-        {
-            return _stream << "topo file: " << val.m_sTopologyFile << "; validation "
-                           << (val.m_nDisiableValidation ? "disabled" : "enabled");
-        }
-        inline bool operator!=(const SSetTopologyCmd& lhs, const SSetTopologyCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SSetTopologyCmd& val);
+        bool operator!=(const SSetTopologyCmd& lhs, const SSetTopologyCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/SimpleMsgCmd.cpp
+++ b/dds-protocol-lib/src/SimpleMsgCmd.cpp
@@ -11,54 +11,47 @@ using namespace dds;
 using namespace dds::protocol_api;
 namespace inet = MiscCommon::INet;
 
-void SSimpleMsgCmd::normalizeToLocal() const
+SSimpleMsgCmd::SSimpleMsgCmd()
+    : m_msgSeverity(0)
+    , m_srcCommand(0)
+    , m_sMsg()
 {
-    m_msgSeverity = inet::normalizeRead(m_msgSeverity);
-    m_srcCommand = inet::normalizeRead(m_srcCommand);
 }
 
-void SSimpleMsgCmd::normalizeToRemote() const
+SSimpleMsgCmd::SSimpleMsgCmd(const std::string& _msg, uint16_t _severity, uint16_t _command)
+    : m_msgSeverity(_severity)
+    , m_srcCommand(_command)
+    , m_sMsg(_msg)
 {
-    m_msgSeverity = inet::normalizeWrite(m_msgSeverity);
-    m_srcCommand = inet::normalizeWrite(m_srcCommand);
+}
+
+size_t SSimpleMsgCmd::size() const
+{
+    return dsize(m_sMsg) + dsize(m_msgSeverity) + dsize(m_srcCommand);
+}
+
+bool SSimpleMsgCmd::operator==(const SSimpleMsgCmd& val) const
+{
+    return (m_sMsg == val.m_sMsg && m_msgSeverity == val.m_msgSeverity && m_srcCommand == val.m_srcCommand);
 }
 
 void SSimpleMsgCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "SimpleMsgCmd: Protocol message data is too short, expected " << size() << " received " << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    size_t idx(0);
-    inet::readData(&m_msgSeverity, &_data, &idx);
-    inet::readData(&m_srcCommand, &_data, &idx);
-
-    vector<string> v;
-    MiscCommon::BYTEVector_t::const_iterator iter = _data.begin();
-    advance(iter, idx);
-    MiscCommon::BYTEVector_t::const_iterator iter_end = _data.end();
-    for (; iter != iter_end;)
-    {
-        string tmp((string::value_type*)(&(*iter)));
-        v.push_back(tmp);
-        advance(iter, tmp.size() + 1);
-    }
-
-    // there are so far only 1 string fields in this msg container
-    if (v.size() != 1)
-        throw runtime_error("SimpleMsgCmd: can't import data. Number of fields doesn't match.");
-
-    m_sMsg.assign(v[0]);
+    SAttachmentDataProvider(_data).get(m_msgSeverity).get(m_srcCommand).get(m_sMsg);
 }
 
 void SSimpleMsgCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    inet::pushData(m_msgSeverity, _data);
-    inet::pushData(m_srcCommand, _data);
+    SAttachmentDataProvider(_data).put(m_msgSeverity).put(m_srcCommand).put(m_sMsg);
+}
 
-    copy(m_sMsg.begin(), m_sMsg.end(), back_inserter(*_data));
-    _data->push_back('\0');
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SSimpleMsgCmd& val)
+{
+    return _stream << "source command: " << val.m_srcCommand << "; severity " << val.m_msgSeverity
+                   << "; Msg: " << val.m_sMsg;
+}
+
+bool dds::protocol_api::operator!=(const SSimpleMsgCmd& lhs, const SSimpleMsgCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/SimpleMsgCmd.h
+++ b/dds-protocol-lib/src/SimpleMsgCmd.h
@@ -15,44 +15,19 @@ namespace dds
     {
         struct SSimpleMsgCmd : public SBasicCmd<SSimpleMsgCmd>
         {
-            SSimpleMsgCmd()
-                : m_msgSeverity(0)
-                , m_srcCommand(0)
-                , m_sMsg()
-            {
-            }
-            SSimpleMsgCmd(const std::string& _msg, uint16_t _severity = MiscCommon::info, uint16_t _command = 0)
-                : m_msgSeverity(_severity)
-                , m_srcCommand(_command)
-                , m_sMsg(_msg)
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                return (m_sMsg.size() + 1) + sizeof(m_msgSeverity) + sizeof(m_srcCommand);
-            }
+            SSimpleMsgCmd();
+            SSimpleMsgCmd(const std::string& _msg, uint16_t _severity = MiscCommon::info, uint16_t _command = 0);
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SSimpleMsgCmd& val) const
-            {
-                return (m_sMsg == val.m_sMsg && m_msgSeverity == val.m_msgSeverity && m_srcCommand == val.m_srcCommand);
-            }
+            bool operator==(const SSimpleMsgCmd& val) const;
 
-            mutable uint16_t m_msgSeverity;
-            mutable uint16_t m_srcCommand;
+            uint16_t m_msgSeverity;
+            uint16_t m_srcCommand;
             std::string m_sMsg;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SSimpleMsgCmd& val)
-        {
-            return _stream << "source command: " << val.m_srcCommand << "; severity " << val.m_msgSeverity
-                           << "; Msg: " << val.m_sMsg;
-        }
-        inline bool operator!=(const SSimpleMsgCmd& lhs, const SSimpleMsgCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SSimpleMsgCmd& val);
+        bool operator!=(const SSimpleMsgCmd& lhs, const SSimpleMsgCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/SubmitCmd.h
+++ b/dds-protocol-lib/src/SubmitCmd.h
@@ -26,39 +26,17 @@ namespace dds
             };
             std::map<uint16_t, std::string> RMSTypeCodeToString = { { SSH, "ssh" }, { LOCALHOST, "localhost" } };
 
-            SSubmitCmd()
-                : m_nRMSTypeCode(0)
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t s = (m_sSSHCfgFile.size() + 1) + sizeof(m_nRMSTypeCode);
-                return s;
-            }
+            SSubmitCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SSubmitCmd& val) const
-            {
-                return (m_sSSHCfgFile == val.m_sSSHCfgFile && m_nRMSTypeCode == val.m_nRMSTypeCode);
-            }
+            bool operator==(const SSubmitCmd& val) const;
 
-            mutable uint16_t m_nRMSTypeCode;
+            uint16_t m_nRMSTypeCode;
             std::string m_sSSHCfgFile;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SSubmitCmd& val)
-        {
-            _stream << "RMS type code: " << val.m_nRMSTypeCode;
-            if (val.m_nRMSTypeCode == SSubmitCmd::SSH)
-                _stream << "; SSH Hosts config: " << val.m_sSSHCfgFile;
-
-            return _stream;
-        }
-        inline bool operator!=(const SSubmitCmd& lhs, const SSubmitCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SSubmitCmd& val);
+        bool operator!=(const SSubmitCmd& lhs, const SSubmitCmd& rhs);
         //=============================================================================
         // A custom streamer to help boost program options to convert string options to ERmsType
         inline std::istream& operator>>(std::istream& _in, SSubmitCmd::ERmsType& _rms)

--- a/dds-protocol-lib/src/UUIDCmd.cpp
+++ b/dds-protocol-lib/src/UUIDCmd.cpp
@@ -11,30 +11,38 @@ using namespace dds;
 using namespace dds::protocol_api;
 namespace inet = MiscCommon::INet;
 
-void SIDCmd::normalizeToLocal() const
+SIDCmd::SIDCmd()
+    : m_id()
 {
-    m_id = inet::normalizeRead(m_id);
 }
 
-void SIDCmd::normalizeToRemote() const
+size_t SIDCmd::size() const
 {
-    m_id = inet::normalizeWrite(m_id);
+    return dsize(m_id);
+}
+
+bool SIDCmd::operator==(const SIDCmd& _val) const
+{
+    return (m_id == _val.m_id);
 }
 
 void SIDCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "SIDCmd: Protocol message data is too short, expected " << size() << " received " << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    size_t idx(0);
-    inet::readData(&m_id, &_data, &idx);
+    SAttachmentDataProvider(_data).get(m_id);
 }
 
 void SIDCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    inet::pushData(m_id, _data);
+    SAttachmentDataProvider(_data).put(m_id);
+}
+
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SIDCmd& _val)
+{
+    _stream << _val.m_id;
+    return _stream;
+}
+
+bool dds::protocol_api::operator!=(const SIDCmd& lhs, const SIDCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/UUIDCmd.h
+++ b/dds-protocol-lib/src/UUIDCmd.h
@@ -13,35 +13,16 @@ namespace dds
     {
         struct SIDCmd : public SBasicCmd<SIDCmd>
         {
-            SIDCmd()
-                : m_id()
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t size(sizeof(m_id));
-                return size;
-            }
+            SIDCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SIDCmd& _val) const
-            {
-                return (m_id == _val.m_id);
-            }
+            bool operator==(const SIDCmd& _val) const;
 
-            mutable uint64_t m_id;
+            uint64_t m_id;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SIDCmd& _val)
-        {
-            _stream << _val.m_id;
-            return _stream;
-        }
-        inline bool operator!=(const SIDCmd& lhs, const SIDCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SIDCmd& _val);
+        bool operator!=(const SIDCmd& lhs, const SIDCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/UpdateKeyCmd.cpp
+++ b/dds-protocol-lib/src/UpdateKeyCmd.cpp
@@ -4,50 +4,45 @@
 //
 #include "UpdateKeyCmd.h"
 #include <stdexcept>
+#include "INet.h"
 
 using namespace std;
 using namespace dds;
 using namespace dds::protocol_api;
+namespace inet = MiscCommon::INet;
 
-void SUpdateKeyCmd::normalizeToLocal() const
+SUpdateKeyCmd::SUpdateKeyCmd()
+    : m_sKey()
+    , m_sValue()
 {
 }
 
-void SUpdateKeyCmd::normalizeToRemote() const
+size_t SUpdateKeyCmd::size() const
 {
+    return dsize(m_sKey) + dsize(m_sValue);
+}
+
+bool SUpdateKeyCmd::operator==(const SUpdateKeyCmd& val) const
+{
+    return (m_sKey == val.m_sKey && m_sValue == val.m_sValue);
 }
 
 void SUpdateKeyCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "UpdateKeyCmd: Protocol message data is too short, expected " << size() << " received " << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    vector<string> v;
-    MiscCommon::BYTEVector_t::const_iterator iter = _data.begin();
-    MiscCommon::BYTEVector_t::const_iterator iter_end = _data.end();
-    for (; iter != iter_end;)
-    {
-        string tmp((string::value_type*)(&(*iter)));
-        v.push_back(tmp);
-        advance(iter, tmp.size() + 1);
-    }
-
-    // there are so far only 2 string fields in this msg container
-    if (v.size() != 2)
-        throw runtime_error("UpdateKeyCmd: can't import data. Number of fields doesn't match.");
-
-    m_sKey.assign(v[0]);
-    m_sValue.assign(v[1]);
+    SAttachmentDataProvider(_data).get(m_sKey).get(m_sValue);
 }
 
 void SUpdateKeyCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    copy(m_sKey.begin(), m_sKey.end(), back_inserter(*_data));
-    _data->push_back('\0');
-    copy(m_sValue.begin(), m_sValue.end(), back_inserter(*_data));
-    _data->push_back('\0');
+    SAttachmentDataProvider(_data).put(m_sKey).put(m_sValue);
+}
+
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SUpdateKeyCmd& val)
+{
+    return _stream << "key: " << val.m_sKey << " Value: " << val.m_sValue;
+}
+
+bool dds::protocol_api::operator!=(const SUpdateKeyCmd& lhs, const SUpdateKeyCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/UpdateKeyCmd.h
+++ b/dds-protocol-lib/src/UpdateKeyCmd.h
@@ -13,34 +13,17 @@ namespace dds
     {
         struct SUpdateKeyCmd : public SBasicCmd<SUpdateKeyCmd>
         {
-            SUpdateKeyCmd()
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                size_t s = (m_sKey.size() + 1) + (m_sValue.size() + 1);
-                return s;
-            }
+            SUpdateKeyCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SUpdateKeyCmd& val) const
-            {
-                return (m_sKey == val.m_sKey && m_sValue == val.m_sValue);
-            }
+            bool operator==(const SUpdateKeyCmd& val) const;
 
             std::string m_sKey;
             std::string m_sValue;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SUpdateKeyCmd& val)
-        {
-            return _stream << "key: " << val.m_sKey << " Value: " << val.m_sValue;
-        }
-        inline bool operator!=(const SUpdateKeyCmd& lhs, const SUpdateKeyCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SUpdateKeyCmd& val);
+        bool operator!=(const SUpdateKeyCmd& lhs, const SUpdateKeyCmd& rhs);
     }
 }
 #endif

--- a/dds-protocol-lib/src/UserTaskDoneCmd.cpp
+++ b/dds-protocol-lib/src/UserTaskDoneCmd.cpp
@@ -11,31 +11,37 @@ using namespace dds;
 using namespace dds::protocol_api;
 namespace inet = MiscCommon::INet;
 
-void SUserTaskDoneCmd::normalizeToLocal() const
+SUserTaskDoneCmd::SUserTaskDoneCmd()
+    : m_exitCode(0)
 {
-    m_exitCode = inet::normalizeRead(m_exitCode);
 }
 
-void SUserTaskDoneCmd::normalizeToRemote() const
+size_t SUserTaskDoneCmd::size() const
 {
-    m_exitCode = inet::normalizeWrite(m_exitCode);
+    return dsize(m_exitCode);
+}
+
+bool SUserTaskDoneCmd::operator==(const SUserTaskDoneCmd& val) const
+{
+    return (m_exitCode == val.m_exitCode);
 }
 
 void SUserTaskDoneCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "SUserTaskDoneCmd: Protocol message data is too short, expected " << size() << " received "
-           << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    size_t idx(0);
-    inet::readData(&m_exitCode, &_data, &idx);
+    SAttachmentDataProvider(_data).get(m_exitCode);
 }
 
 void SUserTaskDoneCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    inet::pushData(m_exitCode, _data);
+    SAttachmentDataProvider(_data).put(m_exitCode);
+}
+
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SUserTaskDoneCmd& val)
+{
+    return _stream << "exit code: " << val.m_exitCode;
+}
+
+bool dds::protocol_api::operator!=(const SUserTaskDoneCmd& lhs, const SUserTaskDoneCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/UserTaskDoneCmd.h
+++ b/dds-protocol-lib/src/UserTaskDoneCmd.h
@@ -14,33 +14,16 @@ namespace dds
     {
         struct SUserTaskDoneCmd : public SBasicCmd<SUserTaskDoneCmd>
         {
-            SUserTaskDoneCmd()
-                : m_exitCode(0)
-            {
-            }
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                return sizeof(m_exitCode);
-            }
+            SUserTaskDoneCmd();
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SUserTaskDoneCmd& val) const
-            {
-                return (m_exitCode == val.m_exitCode);
-            }
+            bool operator==(const SUserTaskDoneCmd& val) const;
 
-            mutable uint32_t m_exitCode;
+            uint32_t m_exitCode;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SUserTaskDoneCmd& val)
-        {
-            return _stream << "exit code: " << val.m_exitCode;
-        }
-        inline bool operator!=(const SUserTaskDoneCmd& lhs, const SUserTaskDoneCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SUserTaskDoneCmd& val);
+        bool operator!=(const SUserTaskDoneCmd& lhs, const SUserTaskDoneCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/src/VersionCmd.cpp
+++ b/dds-protocol-lib/src/VersionCmd.cpp
@@ -19,34 +19,32 @@ SVersionCmd::SVersionCmd()
 {
 }
 
-void SVersionCmd::normalizeToLocal() const
+size_t SVersionCmd::size() const
 {
-    m_version = inet::normalizeRead(m_version);
-    m_channelType = inet::normalizeRead(m_channelType);
+    return dsize(m_version) + dsize(m_channelType);
 }
 
-void SVersionCmd::normalizeToRemote() const
+bool SVersionCmd::operator==(const SVersionCmd& val) const
 {
-    m_version = inet::normalizeWrite(m_version);
-    m_channelType = inet::normalizeWrite(m_channelType);
+    return (m_version == val.m_version) && (m_channelType == val.m_channelType);
 }
 
 void SVersionCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    if (_data.size() < size())
-    {
-        stringstream ss;
-        ss << "VersionCmd: Protocol message data is too short, expected " << size() << " received " << _data.size();
-        throw runtime_error(ss.str());
-    }
-
-    size_t idx(0);
-    inet::readData(&m_version, &_data, &idx);
-    inet::readData(&m_channelType, &_data, &idx);
+    SAttachmentDataProvider(_data).get(m_version).get(m_channelType);
 }
 
 void SVersionCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    inet::pushData(m_version, _data);
-    inet::pushData(m_channelType, _data);
+    SAttachmentDataProvider(_data).put(m_version).put(m_channelType);
+}
+
+std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SVersionCmd& val)
+{
+    return _stream << val.m_version << " " << val.m_channelType;
+}
+
+bool dds::protocol_api::operator!=(const SVersionCmd& lhs, const SVersionCmd& rhs)
+{
+    return !(lhs == rhs);
 }

--- a/dds-protocol-lib/src/VersionCmd.h
+++ b/dds-protocol-lib/src/VersionCmd.h
@@ -17,30 +17,16 @@ namespace dds
         struct SVersionCmd : public SBasicCmd<SVersionCmd>
         {
             SVersionCmd();
-            void normalizeToLocal() const;
-            void normalizeToRemote() const;
-            size_t size() const
-            {
-                return sizeof(m_version) + sizeof(m_channelType);
-            }
+            size_t size() const;
             void _convertFromData(const MiscCommon::BYTEVector_t& _data);
             void _convertToData(MiscCommon::BYTEVector_t* _data) const;
-            bool operator==(const SVersionCmd& val) const
-            {
-                return (m_version == val.m_version) && (m_channelType == val.m_channelType);
-            }
+            bool operator==(const SVersionCmd& val) const;
 
-            mutable uint16_t m_version;
-            mutable uint16_t m_channelType;
+            uint16_t m_version;
+            uint16_t m_channelType;
         };
-        inline std::ostream& operator<<(std::ostream& _stream, const SVersionCmd& val)
-        {
-            return _stream << val.m_version << " " << val.m_channelType;
-        }
-        inline bool operator!=(const SVersionCmd& lhs, const SVersionCmd& rhs)
-        {
-            return !(lhs == rhs);
-        }
+        std::ostream& operator<<(std::ostream& _stream, const SVersionCmd& val);
+        bool operator!=(const SVersionCmd& lhs, const SVersionCmd& rhs);
     }
 }
 

--- a/dds-protocol-lib/tests/CMakeLists.txt
+++ b/dds-protocol-lib/tests/CMakeLists.txt
@@ -13,10 +13,19 @@ include_directories(
 ##################################################################
 
 set( CLNT_SOURCE_FILES
-	./Test_ProtocolMessage.cpp
+   ./Test_ProtocolMessage.cpp
+   ./TestCmd.cpp
 )
 
-add_executable(dds-protocol-lib-ProtocolMessage-tests ${CLNT_SOURCE_FILES})
+set( CLNT_HEADER_FILES
+	./TestCmd.h
+)
+
+if (CMAKE_GENERATOR STREQUAL "Xcode")
+	add_executable(dds-protocol-lib-ProtocolMessage-tests ${CLNT_SOURCE_FILES} ${CLNT_HEADER_FILES})
+else (CMAKE_GENERATOR STREQUAL "Xcode")
+	add_executable(dds-protocol-lib-ProtocolMessage-tests ${CLNT_SOURCE_FILES})
+endif (CMAKE_GENERATOR STREQUAL "Xcode")
 
 target_link_libraries (
 	dds-protocol-lib-ProtocolMessage-tests
@@ -33,4 +42,3 @@ target_include_directories(dds-protocol-lib-ProtocolMessage-tests
 )
 
 install(TARGETS dds-protocol-lib-ProtocolMessage-tests DESTINATION tests)
-

--- a/dds-protocol-lib/tests/TestCmd.cpp
+++ b/dds-protocol-lib/tests/TestCmd.cpp
@@ -1,0 +1,86 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+#include "TestCmd.h"
+// MiscCommon
+#include "INet.h"
+
+using namespace std;
+using namespace dds;
+using namespace dds::protocol_api;
+namespace inet = MiscCommon::INet;
+
+STestCmd::STestCmd()
+    : m_uint16(0)
+    , m_uint32(0)
+    , m_uint64(0)
+    , m_string1()
+    , m_string2()
+    , m_string3()
+    , m_string4()
+    , m_vuint16()
+    , m_vuint32()
+    , m_vuint64()
+    , m_vstring1()
+    , m_vstring2()
+{
+}
+
+size_t STestCmd::size() const
+{
+    return dsize(m_uint16) + dsize(m_uint32) + dsize(m_uint64) + dsize(m_string1) + dsize(m_string2) +
+           dsize(m_string3) + dsize(m_string4) + dsize(m_vuint16) + dsize(m_vuint32) + dsize(m_vuint64) +
+           dsize(m_vstring1) + dsize(m_vstring2);
+}
+
+bool STestCmd::operator==(const STestCmd& val) const
+{
+    return (m_uint16 == val.m_uint16 && m_uint32 == val.m_uint32 && m_uint64 == val.m_uint64 &&
+            m_string1 == val.m_string1 && m_string2 == val.m_string2 && m_string3 == val.m_string3 &&
+            m_string4 == val.m_string4 && m_vuint16 == val.m_vuint16 && m_vuint32 == val.m_vuint32 &&
+            m_vuint64 == val.m_vuint64 && m_vstring1 == val.m_vstring1 && m_vstring2 == val.m_vstring2);
+}
+
+void STestCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
+{
+    SAttachmentDataProvider(_data)
+        .get(m_uint16)
+        .get(m_uint32)
+        .get(m_uint64)
+        .get(m_string1)
+        .get(m_string2)
+        .get(m_vuint16)
+        .get(m_vuint32)
+        .get(m_vstring1)
+        .get(m_string3)
+        .get(m_vuint64)
+        .get(m_vstring2)
+        .get(m_string4);
+}
+
+void STestCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
+{
+    SAttachmentDataProvider(_data)
+        .put(m_uint16)
+        .put(m_uint32)
+        .put(m_uint64)
+        .put(m_string1)
+        .put(m_string2)
+        .put(m_vuint16)
+        .put(m_vuint32)
+        .put(m_vstring1)
+        .put(m_string3)
+        .put(m_vuint64)
+        .put(m_vstring2)
+        .put(m_string4);
+}
+
+inline std::ostream& operator<<(std::ostream& _stream, const STestCmd& val)
+{
+    return _stream << "TestCmd";
+}
+inline bool operator!=(const STestCmd& lhs, const STestCmd& rhs)
+{
+    return !(lhs == rhs);
+}

--- a/dds-protocol-lib/tests/TestCmd.h
+++ b/dds-protocol-lib/tests/TestCmd.h
@@ -1,0 +1,38 @@
+// Copyright 2014 GSI, Inc. All rights reserved.
+//
+//
+//
+#ifndef __DDS__TestCmd__
+#define __DDS__TestCmd__
+
+// DDS
+#include "BasicCmd.h"
+
+namespace dds
+{
+    struct STestCmd : public protocol_api::SBasicCmd<STestCmd>
+    {
+        STestCmd();
+        size_t size() const;
+        void _convertFromData(const MiscCommon::BYTEVector_t& _data);
+        void _convertToData(MiscCommon::BYTEVector_t* _data) const;
+        bool operator==(const STestCmd& val) const;
+
+        uint16_t m_uint16;
+        uint32_t m_uint32;
+        uint64_t m_uint64;
+        std::string m_string1;
+        std::string m_string2;
+        std::string m_string3;
+        std::string m_string4;
+        std::vector<uint16_t> m_vuint16;
+        std::vector<uint32_t> m_vuint32;
+        std::vector<uint64_t> m_vuint64;
+        std::vector<std::string> m_vstring1;
+        std::vector<std::string> m_vstring2;
+    };
+    inline std::ostream& operator<<(std::ostream& _stream, const STestCmd& val);
+    inline bool operator!=(const STestCmd& lhs, const STestCmd& rhs);
+}
+
+#endif /* defined(__DDS__TestCmd__) */

--- a/dds-protocol-lib/tests/Test_ProtocolMessage.cpp
+++ b/dds-protocol-lib/tests/Test_ProtocolMessage.cpp
@@ -22,6 +22,7 @@
 #include "ProtocolCommands.h"
 #include "CommandAttachmentImpl.h"
 #include "def.h"
+#include "TestCmd.h"
 
 using boost::unit_test::test_suite;
 using namespace MiscCommon;
@@ -76,7 +77,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdHANDSHAKE)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdSUBMIT)
 {
-    const unsigned int cmdSize = 25;
+    const unsigned int cmdSize = 26;
 
     SSubmitCmd cmd;
     cmd.m_nRMSTypeCode = 1;
@@ -87,7 +88,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdSUBMIT)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_HOST_INFO)
 {
-    const unsigned int cmdSize = 60;
+    const unsigned int cmdSize = 65;
 
     SHostInfoCmd cmd;
     cmd.m_username = "username";
@@ -111,7 +112,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdBINARY_ATTACHMENT)
     const uint32_t offset = 12345;
     const boost::uuids::uuid fileId = boost::uuids::random_generator()();
 
-    const unsigned int cmdSize = 54;
+    const unsigned int cmdSize = 58;
 
     SBinaryAttachmentCmd cmd;
     cmd.m_data = data;
@@ -125,7 +126,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdBINARY_ATTACHMENT)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdBINARY_ATTACHMENT_RECEIVED)
 {
-    const unsigned int cmdSize = 49;
+    const unsigned int cmdSize = 51;
 
     SBinaryAttachmentReceivedCmd cmd;
     cmd.m_receivedFilePath = "received_file_name";
@@ -139,7 +140,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdBINARY_ATTACHMENT_RECEIVED)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdBINARY_ATTACHMENT_START)
 {
-    const unsigned int cmdSize = 36;
+    const unsigned int cmdSize = 37;
 
     SBinaryAttachmentStartCmd cmd;
     cmd.m_fileId = boost::uuids::random_generator()();
@@ -173,7 +174,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_GET_ID)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdSIMPLE_MSG)
 {
-    const unsigned int cmdSize = 17;
+    const unsigned int cmdSize = 18;
 
     SSimpleMsgCmd cmd;
     cmd.m_srcCommand = cmdSIMPLE_MSG;
@@ -185,7 +186,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdSIMPLE_MSG)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_HANDSHAKE_ERR)
 {
-    const unsigned int cmdSize = 20;
+    const unsigned int cmdSize = 21;
 
     SSimpleMsgCmd cmd;
     cmd.m_srcCommand = cmdREPLY_HANDSHAKE_ERR;
@@ -197,7 +198,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_HANDSHAKE_ERR)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_PID)
 {
-    const unsigned int cmdSize = 10;
+    const unsigned int cmdSize = 11;
 
     SSimpleMsgCmd cmd;
     cmd.m_srcCommand = cmdREPLY_PID;
@@ -219,9 +220,10 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdASSIGN_USER_TASK)
     src.m_collectionName = "collection1";
     src.m_taskName = "task1";
     // expected attachment size
-    const unsigned int cmdSize = src.m_sExeFile.size() + 1 + src.m_sID.size() + 1 + sizeof(uint32_t) +
-                                 sizeof(uint32_t) + src.m_taskPath.size() + 1 + src.m_groupName.size() + 1 +
-                                 src.m_collectionName.size() + 1 + src.m_taskName.size() + 1;
+    const unsigned int cmdSize = src.m_sExeFile.size() + sizeof(uint16_t) + src.m_sID.size() + sizeof(uint16_t) +
+                                 sizeof(uint32_t) + sizeof(uint32_t) + src.m_taskPath.size() + sizeof(uint16_t) +
+                                 src.m_groupName.size() + sizeof(uint16_t) + src.m_collectionName.size() +
+                                 sizeof(uint16_t) + src.m_taskName.size() + sizeof(uint16_t);
 
     TestCommand(src, cmdASSIGN_USER_TASK, cmdSize);
 }
@@ -230,7 +232,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdUPDATE_KEY)
 {
     const string sKey = "test_Key";
     const string sValue = "test_Value";
-    const unsigned int cmdSize = sKey.size() + 1 + sValue.size() + 1;
+    const unsigned int cmdSize = sKey.size() + sizeof(uint16_t) + sValue.size() + sizeof(uint16_t);
 
     SUpdateKeyCmd cmd_src;
     cmd_src.m_sKey = sKey;
@@ -241,7 +243,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdUPDATE_KEY)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdDELETE_KEY)
 {
-    const unsigned int cmdSize = 11;
+    const unsigned int cmdSize = 12;
 
     SDeleteKeyCmd cmd;
     cmd.m_sKey = "0123456789";
@@ -251,7 +253,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdDELETE_KEY)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_AGENTS_INFO)
 {
-    const unsigned int cmdSize = 27;
+    const unsigned int cmdSize = 28;
 
     SAgentsInfoCmd cmd;
     cmd.m_nActiveAgents = 3;
@@ -285,7 +287,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdPROGRESS)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdSET_TOPOLOGY)
 {
-    const unsigned int cmdSize = 27;
+    const unsigned int cmdSize = 28;
 
     SSetTopologyCmd cmd;
     cmd.m_nDisiableValidation = 1;
@@ -296,7 +298,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdSET_TOPOLOGY)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdCUSTOM_CMD)
 {
-    const unsigned int cmdSize = 22;
+    const unsigned int cmdSize = 24;
 
     SCustomCmdCmd cmd;
     cmd.m_sCmd = "cmd";
@@ -304,6 +306,30 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdCUSTOM_CMD)
     cmd.m_senderId = 123456;
 
     TestCommand(cmd, cmdCUSTOM_CMD, cmdSize);
+}
+
+BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdTEST_CMD)
+{
+    const unsigned int cmdSize = 244;
+    const uint16_t cmdTEST_CMD = 1000;
+
+    STestCmd cmd;
+    cmd.m_uint16 = 16;
+    cmd.m_uint32 = 32;
+    cmd.m_uint64 = 64;
+    cmd.m_string1 = "string1";
+    cmd.m_string2 = "string2";
+    cmd.m_string3 = "string3";
+    cmd.m_string4 = "string4";
+    cmd.m_vuint16 = { 16, 17, 18, 19, 20, 21 };
+    cmd.m_vuint32 = { 32, 33, 34, 35, 36, 37, 38 };
+    cmd.m_vuint64 = { 64, 65, 66, 67, 68, 69, 70 };
+    cmd.m_vstring1 = { "string1_1", "string1_2", "string1_3" };
+    cmd.m_vstring2 = { "string2_1", "string2_2", "string2_3", "string2_4", "string2_5" };
+
+    cout << "TestCmd size: " << cmd.size() << endl;
+
+    TestCommand(cmd, cmdTEST_CMD, cmdSize);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
GH-105: dds-protocol: sending of arrays
GH-106: dds-protocol: sending of strings
GH-107: dds-protocol: generalized implementation of DDS commands

- Check malximum size for vectors and strings in commands.
- Size limitations:
   - All vectors (except uint8_t) have a maximum size of uint16_t i.e. 2^16.
   - All vector<uint8_t>'s have a maximum size of uint32_t i.e. 2^32.
   - All std::string's have a maximum size of uint16_t i.e. 2^16.