### PR TITLE
GH-78: dds-protocol: Fix channel stop operation

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,9 +2,10 @@
 
 ## v1.8 (NOT YET RELEASED)
 ### DDS common
-Fixed: an issue that all the key-value update errors were processed as version mismatch errors, which is wrong. A new error type 'key-value not found' was introduced. DDS agent does not send back an updated key if the error was of type 'key-value not found'.    
+Fixed: an issue that all the key-value update errors were processed as version mismatch errors, which is wrong. A new error type 'key-value not found' was introduced. DDS agent does not send back an updated key if the error was of type 'key-value not found'.
+Added: Lobby based deployment. (GH-78)
+Added: Introduced Session ID. (GH-170)
 Added: DDS cmake script learned DDS_LD_LIBRARY_PATH to help users who wants to build WN packages to workaround macos's SIP when a custom installations of gcc/clang is used. (GH-175)   
-Added: Introduced Session ID. (GH-170)   
 
 ### dds-protocol
 Fixed: an issue when decimal type is passed as an argument to the callback function.    

--- a/dds-agent/src/AgentConnectionManager.cpp
+++ b/dds-agent/src/AgentConnectionManager.cpp
@@ -469,8 +469,6 @@ void CAgentConnectionManager::taskExited(int _pid, int _exitCode)
     cmd.m_exitCode = _exitCode;
     cmd.m_taskID = m_SMAgent->getTaskID();
     m_SMAgent->pushMsg<cmdUSER_TASK_DONE>(cmd);
-
-    m_SMIntercomChannel->reinit();
 }
 
 void CAgentConnectionManager::onNewUserTask(pid_t _pid)
@@ -554,5 +552,4 @@ void CAgentConnectionManager::on_cmdSTOP_USER_TASK(const SSenderInfo& _sender,
     terminateChildrenProcesses();
     auto p = _channel.lock();
     p->pushMsg<cmdSIMPLE_MSG>(SSimpleMsgCmd("Done", info, cmdSTOP_USER_TASK));
-    m_SMIntercomChannel->reinit();
 }

--- a/dds-agent/src/SMFWChannel.cpp
+++ b/dds-agent/src/SMFWChannel.cpp
@@ -23,7 +23,7 @@ CSMFWChannel::CSMFWChannel(boost::asio::io_service& _service,
 
 CSMFWChannel::~CSMFWChannel()
 {
-    // removeMessageQueue();
+    removeMessageQueue();
 }
 
 bool CSMFWChannel::on_rawMessage(CProtocolMessage::protocolMessagePtr_t _currentMsg, const SSenderInfo& _sender)


### PR DESCRIPTION
Remove shared memory of the forwarder SM channel.
Use timed_send in message_queue.
Remove reinit of the shared memory channel.
Update release notes