### PR TITLE
Add new cmdMOVE_FILE and fix cmdGET_LOG

### DIFF
--- a/dds-agent/src/AgentConnectionManager.cpp
+++ b/dds-agent/src/AgentConnectionManager.cpp
@@ -31,7 +31,6 @@ CAgentConnectionManager::CAgentConnectionManager(const SOptions_t& _options)
     : m_signals(m_io_service)
     , m_options(_options)
     , m_bStarted(false)
-    , m_isLeaderBasedDeployment(false)
 {
     // Register to handle the signals that indicate when the server should exit.
     // It is safe to register for the same signal multiple times in a program,
@@ -88,7 +87,6 @@ void CAgentConnectionManager::start()
         }
         catch (bi::interprocess_exception& ex)
         {
-            // m_isLeaderBasedDeployment = false;
             // TODO: FIXME: Log the error and process further
             // If we can't allocate mutex - fallback to the direct connection to the DDS commander
 

--- a/dds-agent/src/AgentConnectionManager.h
+++ b/dds-agent/src/AgentConnectionManager.h
@@ -77,7 +77,6 @@ namespace dds
             childrenPidContainer_t m_children;
             std::mutex m_childrenContainerMutex;
             bool m_bStarted;
-            bool m_isLeaderBasedDeployment;
         };
     }
 }

--- a/dds-agent/src/CommanderChannel.cpp
+++ b/dds-agent/src/CommanderChannel.cpp
@@ -6,6 +6,8 @@
 // DDS
 #include "CommanderChannel.h"
 #include "UserDefaults.h"
+// BOOST
+#include <boost/filesystem.hpp>
 
 using namespace MiscCommon;
 using namespace dds;
@@ -13,6 +15,7 @@ using namespace dds::protocol_api;
 using namespace dds::agent_cmd;
 using namespace std;
 using namespace user_defaults_api;
+namespace fs = boost::filesystem;
 
 const uint16_t g_MaxConnectionAttempts = 5;
 
@@ -27,8 +30,34 @@ CCommanderChannel::CCommanderChannel(boost::asio::io_service& _service, uint64_t
 
     m_SMFWChannel->registerHandler<cmdRAW_MSG>(
         [this](const SSenderInfo& _sender, CProtocolMessage::protocolMessagePtr_t _currentMsg) {
-            LOG(debug) << "Raw message pushed to network channel: " << _currentMsg->toString();
-            this->pushMsg(_currentMsg, static_cast<ECmdType>(_currentMsg->header().m_cmd));
+            ECmdType cmd = static_cast<ECmdType>(_currentMsg->header().m_cmd);
+            // cmdFILE_PATH is an exception. We have to forward it as a binary attachment.
+            if (cmd == cmdMOVE_FILE)
+            {
+                LOG(debug) << "cmdMOVE_FILE pushed to network channel: " << _currentMsg->toString();
+                SCommandAttachmentImpl<cmdMOVE_FILE>::ptr_t attachmentPtr =
+                    SCommandAttachmentImpl<cmdMOVE_FILE>::decode(_currentMsg);
+                this->pushBinaryAttachmentCmd(attachmentPtr->m_filePath,
+                                              attachmentPtr->m_requestedFileName,
+                                              attachmentPtr->m_srcCommand,
+                                              _currentMsg->header().m_ID);
+
+                // We take the ownership and we have to delete the file
+                try
+                {
+                    fs::remove(attachmentPtr->m_filePath);
+                }
+                catch (exception& _e)
+                {
+                    LOG(error) << "Can't remove log archive file: " << attachmentPtr->m_filePath
+                               << "; error: " << _e.what();
+                }
+            }
+            else
+            {
+                LOG(debug) << "Raw message pushed to network channel: " << _currentMsg->toString();
+                this->pushMsg(_currentMsg, static_cast<ECmdType>(_currentMsg->header().m_cmd));
+            }
         });
 
     m_SMFWChannel->start();

--- a/dds-protocol-lib/CMakeLists.txt
+++ b/dds-protocol-lib/CMakeLists.txt
@@ -39,6 +39,7 @@ set( SOURCE_FILES
 	./src/StatImpl.cpp
     ./src/CustomCmdCmd.cpp
     ./src/UpdateTopologyCmd.cpp
+    ./src/MoveFileCmd.cpp
 )
 
 set( SRC_HDRS
@@ -75,6 +76,7 @@ set( SRC_HDRS
     ./src/BaseEventHandlersImpl.h
     ./src/ChannelInfo.h
     ./src/ProtocolDef.h
+    ./src/MoveFileCmd.h
 )
 
 include_directories(

--- a/dds-protocol-lib/src/BaseChannelImpl.h
+++ b/dds-protocol-lib/src/BaseChannelImpl.h
@@ -69,7 +69,7 @@ namespace dds
                 {                                                                                                      \
                     typedef typename SCommandAttachmentImpl<cmdBINARY_ATTACHMENT>::ptr_t attahcmentPtr_t;              \
                     attahcmentPtr_t attachmentPtr = SCommandAttachmentImpl<cmdBINARY_ATTACHMENT>::decode(_currentMsg); \
-                    processBinaryAttachmentCmd(sender, attachmentPtr);                                                         \
+                    processBinaryAttachmentCmd(sender, attachmentPtr);                                                 \
                     return;                                                                                            \
                 }                                                                                                      \
                 case cmdBINARY_ATTACHMENT_START:                                                                       \
@@ -77,7 +77,7 @@ namespace dds
                     typedef typename SCommandAttachmentImpl<cmdBINARY_ATTACHMENT_START>::ptr_t attahcmentPtr_t;        \
                     attahcmentPtr_t attachmentPtr =                                                                    \
                         SCommandAttachmentImpl<cmdBINARY_ATTACHMENT_START>::decode(_currentMsg);                       \
-                    processBinaryAttachmentStartCmd(sender, attachmentPtr);                                                    \
+                    processBinaryAttachmentStartCmd(sender, attachmentPtr);                                            \
                     return;                                                                                            \
                 }                                                                                                      \
                 case cmdHANDSHAKE:                                                                                     \
@@ -570,7 +570,8 @@ namespace dds
                 }
             }
 
-            void processBinaryAttachmentStartCmd(const SSenderInfo& _sender, SCommandAttachmentImpl<cmdBINARY_ATTACHMENT_START>::ptr_t _attachment)
+            void processBinaryAttachmentStartCmd(const SSenderInfo& _sender,
+                                                 SCommandAttachmentImpl<cmdBINARY_ATTACHMENT_START>::ptr_t _attachment)
             {
                 boost::uuids::uuid fileId = _attachment->m_fileId;
 
@@ -595,7 +596,8 @@ namespace dds
                 }
             }
 
-            void processBinaryAttachmentCmd(const SSenderInfo& _sender, SCommandAttachmentImpl<cmdBINARY_ATTACHMENT>::ptr_t _attachment)
+            void processBinaryAttachmentCmd(const SSenderInfo& _sender,
+                                            SCommandAttachmentImpl<cmdBINARY_ATTACHMENT>::ptr_t _attachment)
             {
                 boost::uuids::uuid fileId = _attachment->m_fileId;
                 binaryAttachmentInfoPtr_t info;
@@ -633,7 +635,8 @@ namespace dds
                        << " instead of " << _attachment->m_crc32 << "offset=" << _attachment->m_offset
                        << " size=" << _attachment->m_size;
                     LOG(MiscCommon::error) << ss.str();
-                    sendYourself<cmdSIMPLE_MSG>(SSimpleMsgCmd(ss.str(), MiscCommon::error, info->m_srcCommand), _sender.m_ID);
+                    sendYourself<cmdSIMPLE_MSG>(SSimpleMsgCmd(ss.str(), MiscCommon::error, info->m_srcCommand),
+                                                _sender.m_ID);
                     return;
                 }
 
@@ -668,7 +671,8 @@ namespace dds
                                << "] has wrong CRC32 checksum: " << crc32.checksum() << " instead of "
                                << _attachment->m_crc32;
                             LOG(MiscCommon::error) << ss.str();
-                            sendYourself<cmdSIMPLE_MSG>(SSimpleMsgCmd(ss.str(), MiscCommon::error, info->m_srcCommand), _sender.m_ID);
+                            sendYourself<cmdSIMPLE_MSG>(SSimpleMsgCmd(ss.str(), MiscCommon::error, info->m_srcCommand),
+                                                        _sender.m_ID);
                             return;
                         }
 
@@ -686,7 +690,8 @@ namespace dds
                             std::stringstream ss;
                             ss << "Could not open file: " << fileName;
                             LOG(MiscCommon::error) << ss.str();
-                            sendYourself<cmdSIMPLE_MSG>(SSimpleMsgCmd(ss.str(), MiscCommon::error, info->m_srcCommand), _sender.m_ID);
+                            sendYourself<cmdSIMPLE_MSG>(SSimpleMsgCmd(ss.str(), MiscCommon::error, info->m_srcCommand),
+                                                        _sender.m_ID);
                             return;
                         }
 

--- a/dds-protocol-lib/src/CommandAttachmentImpl.h
+++ b/dds-protocol-lib/src/CommandAttachmentImpl.h
@@ -14,6 +14,7 @@
 #include "DeleteKeyCmd.h"
 #include "GetPropValuesCmd.h"
 #include "HostInfoCmd.h"
+#include "MoveFileCmd.h"
 #include "ProgressCmd.h"
 #include "ProtocolCommands.h"
 #include "ProtocolMessage.h"
@@ -101,6 +102,7 @@ namespace dds
         REGISTER_CMD_ATTACHMENT(SSimpleMsgCmd, cmdLOBBY_MEMBER_INFO_ERR)
         REGISTER_CMD_ATTACHMENT(SVersionCmd, cmdLOBBY_MEMBER_HANDSHAKE)
         REGISTER_CMD_ATTACHMENT(SSimpleMsgCmd, cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR)
+        REGISTER_CMD_ATTACHMENT(SMoveFileCmd, cmdMOVE_FILE)
     }
 }
 

--- a/dds-protocol-lib/src/ProtocolCommands.h
+++ b/dds-protocol-lib/src/ProtocolCommands.h
@@ -69,7 +69,8 @@ namespace dds
             cmdLOBBY_MEMBER_INFO_ERR,  // attachment: SSimpleMsgCmd
             cmdLOBBY_MEMBER_HANDSHAKE, // attachment: SVersionCmd
             cmdREPLY_LOBBY_MEMBER_HANDSHAKE_OK,
-            cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR // attachment: SSimpleMsgCmd
+            cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR, // attachment: SSimpleMsgCmd
+            cmdMOVE_FILE                         // attachment: SMoveFileCmd
         };
 
         static std::map<uint16_t, std::string> g_cmdToString{
@@ -117,7 +118,8 @@ namespace dds
             { cmdLOBBY_MEMBER_INFO_ERR, NAME_TO_STRING(cmdLOBBY_MEMBER_INFO_ERR) },
             { cmdLOBBY_MEMBER_HANDSHAKE, NAME_TO_STRING(cmdLOBBY_MEMBER_HANDSHAKE) },
             { cmdREPLY_LOBBY_MEMBER_HANDSHAKE_OK, NAME_TO_STRING(cmdREPLY_LOBBY_MEMBER_HANDSHAKE_OK) },
-            { cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR, NAME_TO_STRING(cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR) }
+            { cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR, NAME_TO_STRING(cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR) },
+            { cmdMOVE_FILE, NAME_TO_STRING(cmdMOVE_FILE) }
         };
     }
 }

--- a/dds-protocol-lib/src/UpdateTopologyCmd.cpp
+++ b/dds-protocol-lib/src/UpdateTopologyCmd.cpp
@@ -41,8 +41,9 @@ void SUpdateTopologyCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 
 std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SUpdateTopologyCmd& val)
 {
-    return _stream << "topo file: " << val.m_sTopologyFile << "; validation: "
-    << (val.m_nDisableValidation ? "disabled" : "enabled") << "; update type: " << val.m_updateType;
+    return _stream << "topo file: " << val.m_sTopologyFile
+                   << "; validation: " << (val.m_nDisableValidation ? "disabled" : "enabled")
+                   << "; update type: " << val.m_updateType;
 }
 bool dds::protocol_api::operator!=(const SUpdateTopologyCmd& lhs, const SUpdateTopologyCmd& rhs)
 {

--- a/dds-protocol-lib/tests/Test_ProtocolMessage.cpp
+++ b/dds-protocol-lib/tests/Test_ProtocolMessage.cpp
@@ -424,4 +424,16 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR)
     TestCommand(cmd, cmdREPLY_LOBBY_MEMBER_HANDSHAKE_ERR, cmdSize);
 }
 
+BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdFILE_PATH)
+{
+    const unsigned int cmdSize = 27;
+
+    SMoveFileCmd cmd;
+    cmd.m_filePath = "/path/to/file";
+    cmd.m_srcCommand = cmdGET_LOG;
+    cmd.m_requestedFileName = "logs.zip";
+
+    TestCommand(cmd, cmdMOVE_FILE, cmdSize);
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
dds-protocol: Add new cmdMOVE_FILE for efficient transfer of files via shared memory channels without copying.
Simplify agents code of cmdGET_LOG which utilises now new cmdMOVE_FILE.
Agents forwarder channel processes cmdMOVE_FILE as a special case.