### PR TITLE
Fix dds-intercom-lib for external utilities

### DIFF
--- a/dds-intercom-lib/src/DDSIntercomGuard.h
+++ b/dds-intercom-lib/src/DDSIntercomGuard.h
@@ -87,7 +87,7 @@ namespace dds
             void waitCondition();
             void stopCondition();
 
-            void start();
+            void start(const std::string& _sessionID);
             void stop();
 
             void initAgentConnection();

--- a/dds-intercom-lib/src/dds_intercom.cpp
+++ b/dds-intercom-lib/src/dds_intercom.cpp
@@ -22,9 +22,9 @@ void CIntercomService::subscribeOnError(errorSignal_t::slot_function_type _subsc
     connection_t connection = CDDSIntercomGuard::instance().connectError(_subscriber);
 }
 
-void CIntercomService::start()
+void CIntercomService::start(const std::string& _sessionID)
 {
-    CDDSIntercomGuard::instance().start();
+    CDDSIntercomGuard::instance().start(_sessionID);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/dds-intercom-lib/src/dds_intercom.h
+++ b/dds-intercom-lib/src/dds_intercom.h
@@ -37,7 +37,7 @@ namespace dds
             /// \brief Subscribe on error messages from DDS intercom service
             void subscribeOnError(errorSignal_t::slot_function_type _subscriber);
             /// \brief Start DDS service, i.e. receiving and sending messages.
-            void start();
+            void start(const std::string& _sessionID = "");
         };
 
         ///////////////////////////////////

--- a/dds-tutorials/dds-tutorial2/ui-custom-cmd.cpp
+++ b/dds-tutorials/dds-tutorial2/ui-custom-cmd.cpp
@@ -24,14 +24,22 @@ int main(int argc, char* argv[])
 {
     try
     {
+        std::string sessionID("");
+        
         // Generic options
         bpo::options_description options("ui-custom-cmd options");
         options.add_options()("help,h", "Produce help message");
+        options.add_options()("session,s", bpo::value<std::string>(&sessionID), "DDS Session ID");
 
         // Parsing command-line
         bpo::variables_map vm;
         bpo::store(bpo::command_line_parser(argc, argv).options(options).run(), vm);
         bpo::notify(vm);
+        
+        if (!vm.count("session")) {
+            cout << "DDS session ID is not provided" << endl;
+            return EXIT_SUCCESS;
+        }
 
         atomic<size_t> counterCmdMessages(0);
         atomic<size_t> counterReplyMessages(0);
@@ -60,7 +68,7 @@ int main(int argc, char* argv[])
             counterReplyMessages++;
         });
 
-        service.start();
+        service.start(sessionID);
 
         while (true)
         {


### PR DESCRIPTION
User has to provide a proper DDS session ID for DDSIntercomService in order to be able to connect to a certain dds-commander.